### PR TITLE
Created date decoding convenience method

### DIFF
--- a/Sources/SpotHeroAPI/Core/Extensions/KeyedDecodingContainer+DecodeDateOnly.swift
+++ b/Sources/SpotHeroAPI/Core/Extensions/KeyedDecodingContainer+DecodeDateOnly.swift
@@ -3,6 +3,11 @@
 import Foundation
 
 extension KeyedDecodingContainer {
+    /// Decodes a `Date` object from an ISO-8601 date string in the format `yyyy-MM-dd`.
+    /// - Parameter key: The key that the decoded value is associated with.
+    /// - Throws: A `DecodingError.dataCorruptedError` if the format is incorrect.
+    ///           This is the same error that would be thrown if the standard `decode` function was used.
+    /// - Returns: A `Date` object localized to the current device locale.
     func decodeDateOnly(forKey key: KeyedDecodingContainer<K>.Key) throws -> Date {
         let dateFormat = "yyyy-MM-dd"
         

--- a/Sources/SpotHeroAPI/Core/Extensions/KeyedDecodingContainer+DecodeDateOnly.swift
+++ b/Sources/SpotHeroAPI/Core/Extensions/KeyedDecodingContainer+DecodeDateOnly.swift
@@ -1,0 +1,24 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+extension KeyedDecodingContainer {
+    func decodeDateOnly(forKey key: KeyedDecodingContainer<K>.Key) throws -> Date {
+        let dateFormat = "yyyy-MM-dd"
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        
+        let dateString = try self.decode(String.self, forKey: key)
+        
+        if let date = dateFormatter.date(from: dateString) {
+            return date
+        } else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: self,
+                debugDescription: "Date string does not match format '\(dateFormat)' expected by formatter."
+            )
+        }
+    }
+}

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyReservationDates.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyReservationDates.swift
@@ -4,13 +4,18 @@ import Foundation
 
 /// Represents a pair of start/end dates.
 public struct MonthlyReservationDates: Codable {
-    /// Represents the instant at which a reservation starts.
-    /// Localized in the time zone of the facility.
-    /// Formatted as an ISO-8601 (RFC 3339) datetime.
+    /// The date that a reservation starts.
+    /// Formatted as an ISO-8601 (RFC 3339) datetime in the 'yyyy-MM-dd' format.
     public let starts: Date
     
-    /// Represents the instant at which a reservation ends.
-    /// Localized in the time zone of the facility.
-    /// Formatted as an ISO-8601 (RFC 3339) datetime.
+    /// The date that a reservation ends.
+    /// Formatted as an ISO-8601 (RFC 3339) datetime in the 'yyyy-MM-dd' format.
     public let ends: Date
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.starts = try container.decodeDateOnly(forKey: .starts)
+        self.ends = try container.decodeDateOnly(forKey: .ends)
+    }
 }


### PR DESCRIPTION
**Description**
- Added `KeyedDecodingContainer.decodeDateOnly` so we can very simply add decoding for `Date` types that match the `yyyy-MM-dd` format.