### PR TITLE
Updated APITestCase to include CRAIG URL

### DIFF
--- a/Tests/SpotHeroAPITests/Core/APITestCase.swift
+++ b/Tests/SpotHeroAPITests/Core/APITestCase.swift
@@ -5,15 +5,19 @@ import Sham
 import XCTest
 
 class APITestCase: XCTestCase {
-    static var timeout: TimeInterval = 5
-    static var baseURL: String = "https://mobile.staging.spothero.com"
-    
-    static func newAPIClient() -> SpotHeroAPIClient {
-        return SpotHeroAPIClient(baseURL: Self.baseURL)
+    enum ServiceURL: String {
+        case monolith = "https://mobile.staging.spothero.com"
+        case craig = "https://api.sandbox.spothero.com"
     }
     
-    static func newNetworkClient() -> NetworkClient {
-        return NetworkClient(baseURL: Self.baseURL)
+    static var timeout: TimeInterval = 15
+    
+    static func newAPIClient(for service: ServiceURL) -> SpotHeroAPIClient {
+        return SpotHeroAPIClient(baseURL: service.rawValue)
+    }
+    
+    static func newNetworkClient(for service: ServiceURL) -> NetworkClient {
+        return NetworkClient(baseURL: service.rawValue)
     }
 }
 


### PR DESCRIPTION
**Description**
- Added `ServiceURL` enum for easy configuration between `monolith` and `craig` endpoints. This will get updated as more environments are added but is primarily intended for testing at this time.
