### PR TITLE
IOS-2256: Implemented searchTransientParking GET Request

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Enums/AmenityType.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Enums/AmenityType.swift
@@ -20,6 +20,8 @@ public enum AmenityType: String, Codable {
     case selfPark = "self_park"
     /// The facility has a shuttle available to nearby destinations, like an airport.
     case shuttle
+    /// Entering/exiting the facility does not require touching shared surfaces.
+    case touchless
     /// A valet will park the user's vehicle at this facility.
     case valet
     /// The facility is wheelchair accessible.

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -1,0 +1,121 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import UtilityBeltNetworking
+
+/// Represents a request for fetching transient facilities.
+///
+/// - See [searchTransientParking](https://s3.amazonaws.com/spothe.ro/craig-v2-api.html#operation/searchTransientParking).
+public struct SearchGetTransientFacilitiesRequest: RequestDefining {
+    public typealias ResponseModel = TransientFacilitiesSearchResponse
+    
+    static let method: HTTPMethod = .get
+    static let route = "/v2/search/transient"
+    
+    let client: NetworkClient
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    @discardableResult
+    func callAsFunction(parameters: Parameters,
+                        completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+        return self.client.request(
+            Self.self,
+            parameters: parameters,
+            completion: completion
+        )
+    }
+}
+
+// MARK: - Parameters
+
+extension SearchGetTransientFacilitiesRequest {
+    /// Represents the query parameters used for fetching transient facilities.
+    struct Parameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case endDate = "ends"
+            case latitude = "lat"
+            case longitude = "lon"
+            case isOversize = "oversize"
+            case startDate = "starts"
+            case maxDistanceMeters = "max_distance_meters"
+            case pageSize = "page_size"
+        }
+        
+        /// Latitude in decimal degrees of origin from where the search will be performed. Latitude must be in [-90, 90].
+        let latitude: Double
+        
+        /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
+        let longitude: Double
+        
+        /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated from the time at which the request was received.
+        let startDate: Date?
+        
+        /// End datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated for 3 hours after the start time.
+        let endDate: Date?
+        
+        /// Boolean that denotes whether or not the pricing calculated for this vehicle
+        /// will incorporate pricing for an oversize vehicle, if applicable.
+        let isOversize: Bool?
+        
+        /// Maximum distance in meters from the origin from which facility results will be generated.
+        /// The default is 1609.34 meters (1 mile). The limit is 160934 meters (100 miles).
+        let maxDistanceMeters: Int?
+        
+        /// The number of results to include in a single page.
+        /// The default is nil (no limit). Must be >= 1, if provided.
+        let pageSize: Int?
+        
+        init(latitude: Double,
+             longitude: Double,
+             startDate: Date? = nil,
+             endDate: Date? = nil,
+             isOversize: Bool? = nil,
+             maxDistanceMeters: Int? = nil,
+             pageSize: Int? = nil) {
+            self.latitude = latitude
+            self.longitude = longitude
+            self.startDate = startDate
+            self.endDate = endDate
+            self.isOversize = isOversize
+            self.maxDistanceMeters = maxDistanceMeters
+            self.pageSize = pageSize
+        }
+    }
+}
+
+extension SearchGetTransientFacilitiesRequest.Parameters: ParameterDictionaryConvertible {
+    func asParameterDictionary() -> [String: Any]? {
+        var parameters: [String: Any] = [:]
+        parameters[Self.CodingKeys.latitude.rawValue] = self.latitude
+        parameters[Self.CodingKeys.longitude.rawValue] = self.longitude
+        
+        if let startDate = self.startDate {
+            parameters[Self.CodingKeys.startDate.rawValue] = ISO8601DateFormatter().string(from: startDate)
+        }
+        
+        if let endDate = self.endDate {
+            parameters[Self.CodingKeys.endDate.rawValue] = ISO8601DateFormatter().string(from: endDate)
+        }
+        
+        if let isOversize = self.isOversize {
+            parameters[Self.CodingKeys.isOversize.rawValue] = isOversize
+        }
+        
+        if let maxDistanceMeters = self.maxDistanceMeters {
+            parameters[Self.CodingKeys.maxDistanceMeters.rawValue] = maxDistanceMeters
+        }
+        
+        if let pageSize = self.pageSize {
+            parameters[Self.CodingKeys.pageSize.rawValue] = pageSize
+        }
+        
+        return parameters
+    }
+}

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -19,8 +19,8 @@ public struct SearchGetTransientFacilitiesRequest: RequestDefining {
     }
     
     @discardableResult
-    func callAsFunction(parameters: Parameters,
-                        completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+    public func callAsFunction(parameters: Parameters,
+                               completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
         return self.client.request(
             Self.self,
             parameters: parameters,
@@ -31,7 +31,7 @@ public struct SearchGetTransientFacilitiesRequest: RequestDefining {
 
 // MARK: - Parameters
 
-extension SearchGetTransientFacilitiesRequest {
+public extension SearchGetTransientFacilitiesRequest {
     /// Represents the query parameters used for fetching transient facilities.
     struct Parameters: Encodable {
         private enum CodingKeys: String, CodingKey {
@@ -45,32 +45,32 @@ extension SearchGetTransientFacilitiesRequest {
         }
         
         /// Latitude in decimal degrees of origin from where the search will be performed. Latitude must be in [-90, 90].
-        let latitude: Double
+        private let latitude: Double
         
         /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
-        let longitude: Double
+        private let longitude: Double
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
         /// If this parameter is not provided, results will be generated from the time at which the request was received.
-        let startDate: Date?
+        private let startDate: Date?
         
         /// End datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
         /// If this parameter is not provided, results will be generated for 3 hours after the start time.
-        let endDate: Date?
+        private let endDate: Date?
         
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
-        let isOversize: Bool?
+        private let isOversize: Bool?
         
         /// Maximum distance in meters from the origin from which facility results will be generated.
         /// The default is 1609.34 meters (1 mile). The limit is 160934 meters (100 miles).
-        let maxDistanceMeters: Int?
+        private let maxDistanceMeters: Int?
         
         /// The number of results to include in a single page.
         /// The default is nil (no limit). Must be >= 1, if provided.
-        let pageSize: Int?
+        private let pageSize: Int?
         
         init(latitude: Double,
              longitude: Double,
@@ -91,7 +91,7 @@ extension SearchGetTransientFacilitiesRequest {
 }
 
 extension SearchGetTransientFacilitiesRequest.Parameters: ParameterDictionaryConvertible {
-    func asParameterDictionary() -> [String: Any]? {
+    public func asParameterDictionary() -> [String: Any]? {
         var parameters: [String: Any] = [:]
         parameters[Self.CodingKeys.latitude.rawValue] = self.latitude
         parameters[Self.CodingKeys.longitude.rawValue] = self.longitude

--- a/Tests/SpotHeroAPITests/Resources/MockFiles.bundle/CRAIG/Search/get_transient_facilities.json
+++ b/Tests/SpotHeroAPITests/Resources/MockFiles.bundle/CRAIG/Search/get_transient_facilities.json
@@ -1,0 +1,1060 @@
+{
+  "results": [
+    {
+      "distance": {
+        "linear_meters": 54.85060652347422
+      },
+      "facility": {
+        "common": {
+          "id": "2175",
+          "title": "318 S Federal St. - South Loop Garage",
+          "addresses": [
+            {
+              "id": "2283",
+              "city": "Chicago",
+              "latitude": 41.8776231828,
+              "longitude": -87.6299697423,
+              "state": "IL",
+              "street_address": "318 South Federal Street",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "physical",
+                "search",
+                "walking_distance",
+                "default_vehicle_entrance"
+              ],
+              "postal_code": "60604"
+            },
+            {
+              "id": "2284",
+              "city": "Chicago",
+              "latitude": 41.877150308281614,
+              "longitude": -87.62986063957214,
+              "state": "IL",
+              "street_address": "64 West Van Buren Street",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "vehicle_entrance"
+              ],
+              "postal_code": "60605"
+            }
+          ],
+          "description": "",
+          "facility_type": "garage",
+          "navigation_tip": "Enter this location at 318 S Federal St. This garage is operated by InterPark. It is located on the west side of S Federal St. between W Jackson Blvd. and W Van Buren St. You may also enter this location at its other entrance, 64 W Van Buren St.",
+          "clearance_inches": 82,
+          "hours_of_operation": {
+            "periods": [],
+            "always_open": true
+          },
+          "images": [
+            {
+              "id": "5200",
+              "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302505/la0i1xbcdxgvdbtozxou.jpg",
+              "alt_text": "318 South Federal Street Parking"
+            },
+            {
+              "id": "7528",
+              "url": "https://res.cloudinary.com/spothero/w_535,h_657,x_267,y_328,q_50,c_fill,g_xy_center,f_auto/v1433973814/m6bkw19hfnp35ntxvqfg.png",
+              "alt_text": "318 South Federal Street Parking"
+            },
+            {
+              "id": "5199",
+              "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302489/ugzqq0ojnpzobffynqj9.jpg",
+              "alt_text": "318 South Federal Street Parking"
+            },
+            {
+              "id": "5198",
+              "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302467/kabrjdjtgne3jnbjrigg.jpg",
+              "alt_text": "318 South Federal Street Parking"
+            },
+            {
+              "id": "5202",
+              "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302529/ywy7jgp78kfg45ylbbgk.jpg",
+              "alt_text": "318 South Federal Street Parking"
+            },
+            {
+              "id": "5201",
+              "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302515/agh8987y9rmzvnduipnv.jpg",
+              "alt_text": "318 South Federal Street Parking"
+            }
+          ],
+          "parking_types": [
+            "transient"
+          ],
+          "rating": {
+            "average": 4.602529960053262,
+            "count": 6008
+          },
+          "restrictions": [
+            "Height restriction: 82 inches"
+          ],
+          "requirements": {
+            "printout": false,
+            "license_plate": false,
+            "phone_number": false
+          },
+          "supported_fee_types": [
+            "blanket_fee",
+            "facility_fee"
+          ],
+          "@availability": "https://api.sandbox.spothero.com/v2/search/transient/2175"
+        },
+        "transient": {
+          "redemption_instructions": {
+            "drive_up": [
+              {
+                "id": "39859",
+                "illustration": {
+                  "id": "1",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636831/jxvqbxtqj6tvdvdv0ytj.png",
+                  "alt_text": "Valet Pass Check"
+                },
+                "text": "<p>When you're ready to go, show the valet your ticket and your car will be retrieved. cherries</p>"
+              },
+              {
+                "id": "39853",
+                "illustration": {
+                  "id": "1",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636831/jxvqbxtqj6tvdvdv0ytj.png",
+                  "alt_text": "Valet Pass Check"
+                },
+                "text": "<p>When you're ready to go, show the valet your ticket and your car will be retrieved. apples</p>"
+              }
+            ]
+          }
+        }
+      },
+      "rates": [
+        {
+          "transient": {
+            "redemption_type": "self",
+            "amenities": [
+              {
+                "type": "covered",
+                "description": "The facility has a roof over the vehicles."
+              },
+              {
+                "type": "ev",
+                "description": "The facility has EV charging capabilities."
+              },
+              {
+                "type": "attendant",
+                "description": "The facility has staff on-site for assistance and questions."
+              },
+              {
+                "type": "paved",
+                "description": "The surface of the facility is solid, such as asphalt or concrete."
+              },
+              {
+                "type": "self_park",
+                "description": "Users may park their own vehicles at this facility."
+              },
+              {
+                "type": "touchless",
+                "description": "Entering/exiting the facility does not require touching shared surfaces."
+              }
+            ]
+          },
+          "quote": {
+            "order": [
+              {
+                "facility_id": "2175",
+                "starts": "2020-07-29T14:43:38-05:00",
+                "ends": "2020-07-29T17:43:38-05:00",
+                "rate_id": "2088",
+                "items": [
+                  {
+                    "price": {
+                      "value": 1575,
+                      "currency_code": "USD"
+                    },
+                    "type": "rental",
+                    "short_description": "Subtotal",
+                    "full_description": ""
+                  },
+                  {
+                    "price": {
+                      "value": 50,
+                      "currency_code": "USD"
+                    },
+                    "type": "blanket_fee",
+                    "short_description": "Service Fee",
+                    "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                  }
+                ],
+                "total_price": {
+                  "value": 1625,
+                  "currency_code": "USD"
+                },
+                "meta": {}
+              }
+            ],
+            "items": [
+              {
+                "price": {
+                  "value": 1575,
+                  "currency_code": "USD"
+                },
+                "type": "rental",
+                "short_description": "Subtotal",
+                "full_description": ""
+              },
+              {
+                "price": {
+                  "value": 50,
+                  "currency_code": "USD"
+                },
+                "type": "blanket_fee",
+                "short_description": "Service Fee",
+                "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+              }
+            ],
+            "total_price": {
+              "value": 1625,
+              "currency_code": "USD"
+            },
+            "advertised_price": {
+              "value": 1575,
+              "currency_code": "USD"
+            },
+            "meta": {
+              "quote_mac": "2088",
+              "quote_valid_until": "2020-07-29T17:43:38-05:00",
+              "partner_id": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "distance": {
+        "linear_meters": 126.16048646172203
+      },
+      "facility": {
+        "common": {
+          "id": "769",
+          "title": "Test Spot 2 - Garage",
+          "addresses": [
+            {
+              "id": "694",
+              "city": "Chicago",
+              "latitude": 41.877818,
+              "longitude": -87.631276,
+              "state": "IL",
+              "street_address": "111 West Jackson Boulevard",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "physical",
+                "search",
+                "walking_distance",
+                "default_vehicle_entrance"
+              ],
+              "postal_code": "60604"
+            }
+          ],
+          "description": "",
+          "facility_type": "garage",
+          "navigation_tip": "Enter this location at 316 S Clark St. This is the Chicago Board of Trade garage operated by ABM. It is located on the west/right-hand side of Clark St. (a one-way street) between W Jackson Blvd. and W Van Buren St.",
+          "clearance_inches": 68,
+          "hours_of_operation": {
+            "periods": [
+              {
+                "day_of_week": "monday",
+                "start_time_secs": 21600,
+                "end_time_secs": 68400
+              },
+              {
+                "day_of_week": "tuesday",
+                "start_time_secs": 21600,
+                "end_time_secs": 68400
+              },
+              {
+                "day_of_week": "wednesday",
+                "start_time_secs": 21600,
+                "end_time_secs": 68400
+              },
+              {
+                "day_of_week": "thursday",
+                "start_time_secs": 21600,
+                "end_time_secs": 68400
+              },
+              {
+                "day_of_week": "friday",
+                "start_time_secs": 21600,
+                "end_time_secs": 68400
+              }
+            ],
+            "always_open": false
+          },
+          "images": [
+            {
+              "id": "9139",
+              "url": "https://res.cloudinary.com/spothero/w_5760,h_3840,x_2880,y_1920,q_50,c_fill,g_xy_center,f_auto/v1444670651/uxbuqktqm3gazoxsojpn.jpg",
+              "alt_text": "111 West Jackson Boulevard Parking"
+            },
+            {
+              "id": "9143",
+              "url": "https://res.cloudinary.com/spothero/w_5760,h_3840,x_2880,y_1920,q_50,c_fill,g_xy_center,f_auto/v1444670682/krdfhidancrbftwfcm9i.jpg",
+              "alt_text": "111 West Jackson Boulevard Parking"
+            },
+            {
+              "id": "9142",
+              "url": "https://res.cloudinary.com/spothero/w_5760,h_3840,x_2880,y_1920,q_50,c_fill,g_xy_center,f_auto/v1444670671/aid6h3pzbu3erqbw3yu7.jpg",
+              "alt_text": "111 West Jackson Boulevard Parking"
+            },
+            {
+              "id": "9141",
+              "url": "https://res.cloudinary.com/spothero/w_5760,h_3840,x_2880,y_1920,q_50,c_fill,g_xy_center,f_auto/v1444670661/h1nmcidksjcezf4v2lbq.jpg",
+              "alt_text": "111 West Jackson Boulevard Parking"
+            }
+          ],
+          "parking_types": [
+            "transient",
+            "monthly"
+          ],
+          "rating": {
+            "average": 4,
+            "count": 9
+          },
+          "restrictions": [
+            "Height restriction: 68 inches",
+            "If you purchase evening parking, you MUST enter between 5:00-7:00pm. There will not be an attendant present after 7:00pm."
+          ],
+          "requirements": {
+            "printout": false,
+            "license_plate": true,
+            "phone_number": false
+          },
+          "supported_fee_types": [
+            "blanket_fee"
+          ],
+          "@availability": "https://api.sandbox.spothero.com/v2/search/transient/769"
+        },
+        "transient": {
+          "redemption_instructions": {
+            "drive_up": [
+              {
+                "id": "5164",
+                "illustration": {
+                  "id": "9",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636043/rc6uuzecbw3nfth0hlky.png",
+                  "alt_text": "Pass Check Attendant"
+                },
+                "text": "Show the Attendant your SpotHero Parking Pass, either printed or on a mobile device."
+              },
+              {
+                "id": "5165",
+                "illustration": {
+                  "id": "7",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636122/b2omz3upgcpjn44cyhjb.png",
+                  "alt_text": "Park Where"
+                },
+                "text": "You may park anywhere that doesn't say \"Reserved\"."
+              },
+              {
+                "id": "5166",
+                "illustration": {
+                  "id": "8",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636065/hodnezajkpxuiisu0i4e.png",
+                  "alt_text": "See Ya (Wave)"
+                },
+                "text": "Simply leave when you're ready to go!"
+              }
+            ]
+          }
+        }
+      },
+      "rates": [
+        {
+          "transient": {
+            "redemption_type": "self",
+            "amenities": [
+              {
+                "type": "covered",
+                "description": "The facility has a roof over the vehicles."
+              },
+              {
+                "type": "wheelchair_accessible",
+                "description": "The facility is wheelchair accessible."
+              },
+              {
+                "type": "attendant",
+                "description": "The facility has staff on-site for assistance and questions."
+              },
+              {
+                "type": "paved",
+                "description": "The surface of the facility is solid, such as asphalt or concrete."
+              },
+              {
+                "type": "self_park",
+                "description": "Users may park their own vehicles at this facility."
+              }
+            ]
+          },
+          "quote": {
+            "order": [
+              {
+                "facility_id": "769",
+                "starts": "2020-07-29T14:43:38-05:00",
+                "ends": "2020-07-29T18:00:00-05:00",
+                "rate_id": "694",
+                "items": [
+                  {
+                    "price": {
+                      "value": 2000,
+                      "currency_code": "USD"
+                    },
+                    "type": "rental",
+                    "short_description": "Subtotal",
+                    "full_description": ""
+                  },
+                  {
+                    "price": {
+                      "value": 50,
+                      "currency_code": "USD"
+                    },
+                    "type": "blanket_fee",
+                    "short_description": "Service Fee",
+                    "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                  }
+                ],
+                "total_price": {
+                  "value": 2050,
+                  "currency_code": "USD"
+                },
+                "meta": {}
+              }
+            ],
+            "items": [
+              {
+                "price": {
+                  "value": 2000,
+                  "currency_code": "USD"
+                },
+                "type": "rental",
+                "short_description": "Subtotal",
+                "full_description": ""
+              },
+              {
+                "price": {
+                  "value": 50,
+                  "currency_code": "USD"
+                },
+                "type": "blanket_fee",
+                "short_description": "Service Fee",
+                "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+              }
+            ],
+            "total_price": {
+              "value": 2050,
+              "currency_code": "USD"
+            },
+            "advertised_price": {
+              "value": 2000,
+              "currency_code": "USD"
+            },
+            "meta": {
+              "quote_mac": "694",
+              "quote_valid_until": "2020-07-29T18:00:00-05:00",
+              "partner_id": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "distance": {
+        "linear_meters": 128.53224285516728
+      },
+      "facility": {
+        "common": {
+          "id": "2333",
+          "title": "64 W Van Buren St. - South Loop Garage",
+          "addresses": [
+            {
+              "id": "2501",
+              "city": "Chicago",
+              "latitude": 41.876983696308194,
+              "longitude": -87.63020293624572,
+              "state": "IL",
+              "street_address": "64 West Van Buren Street",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "physical",
+                "search",
+                "walking_distance",
+                "default_vehicle_entrance"
+              ],
+              "postal_code": "60605"
+            }
+          ],
+          "description": "",
+          "facility_type": "garage",
+          "navigation_tip": "Enter this location at 64 W Van Buren St. This garage is operated by InterPark. It is located on the north/right-hand side of W Van Buren St. (a one-way street) between S Federal St. and S Clark St. You may also enter this location at its other entrance, 318 S Federal St.",
+          "clearance_inches": 82,
+          "hours_of_operation": {
+            "periods": [],
+            "always_open": true
+          },
+          "images": [
+            {
+              "id": "5622",
+              "url": "https://res.cloudinary.com/spothero/w_3264,h_2448,x_1632,y_1224,q_50,c_fill,g_xy_center,f_auto/v1425530511/qrryv2hh6fjhpj9saqmt.jpg",
+              "alt_text": "64 West Van Buren Street Parking"
+            }
+          ],
+          "parking_types": [
+            "transient"
+          ],
+          "rating": {
+            "average": 4.602529960053262,
+            "count": 6008
+          },
+          "restrictions": [],
+          "requirements": {
+            "printout": false,
+            "license_plate": false,
+            "phone_number": false
+          },
+          "supported_fee_types": [
+            "blanket_fee"
+          ],
+          "@availability": "https://api.sandbox.spothero.com/v2/search/transient/2333"
+        },
+        "transient": {
+          "redemption_instructions": {
+            "drive_up": []
+          }
+        }
+      },
+      "rates": [
+        {
+          "transient": {
+            "redemption_type": "self",
+            "amenities": [
+              {
+                "type": "covered",
+                "description": "The facility has a roof over the vehicles."
+              },
+              {
+                "type": "ev",
+                "description": "The facility has EV charging capabilities."
+              },
+              {
+                "type": "attendant",
+                "description": "The facility has staff on-site for assistance and questions."
+              },
+              {
+                "type": "paved",
+                "description": "The surface of the facility is solid, such as asphalt or concrete."
+              },
+              {
+                "type": "self_park",
+                "description": "Users may park their own vehicles at this facility."
+              },
+              {
+                "type": "touchless",
+                "description": "Entering/exiting the facility does not require touching shared surfaces."
+              }
+            ]
+          },
+          "quote": {
+            "order": [
+              {
+                "facility_id": "2333",
+                "starts": "2020-07-29T14:43:38-05:00",
+                "ends": "2020-07-29T17:43:38-05:00",
+                "rate_id": "2088",
+                "items": [
+                  {
+                    "price": {
+                      "value": 1575,
+                      "currency_code": "USD"
+                    },
+                    "type": "rental",
+                    "short_description": "Subtotal",
+                    "full_description": ""
+                  },
+                  {
+                    "price": {
+                      "value": 50,
+                      "currency_code": "USD"
+                    },
+                    "type": "blanket_fee",
+                    "short_description": "Service Fee",
+                    "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                  }
+                ],
+                "total_price": {
+                  "value": 1625,
+                  "currency_code": "USD"
+                },
+                "meta": {}
+              }
+            ],
+            "items": [
+              {
+                "price": {
+                  "value": 1575,
+                  "currency_code": "USD"
+                },
+                "type": "rental",
+                "short_description": "Subtotal",
+                "full_description": ""
+              },
+              {
+                "price": {
+                  "value": 50,
+                  "currency_code": "USD"
+                },
+                "type": "blanket_fee",
+                "short_description": "Service Fee",
+                "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+              }
+            ],
+            "total_price": {
+              "value": 1625,
+              "currency_code": "USD"
+            },
+            "advertised_price": {
+              "value": 1575,
+              "currency_code": "USD"
+            },
+            "meta": {
+              "quote_mac": "2088",
+              "quote_valid_until": "2020-07-29T17:43:38-05:00",
+              "partner_id": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "distance": {
+        "linear_meters": 179.73179975886384
+      },
+      "facility": {
+        "common": {
+          "id": "978",
+          "title": "412 S Dearborn St. - Valet/Self Park",
+          "addresses": [
+            {
+              "id": "901",
+              "city": "Chicago",
+              "latitude": 41.876496,
+              "longitude": -87.629532,
+              "state": "IL",
+              "street_address": "412 South Dearborn Street",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "physical",
+                "search",
+                "walking_distance",
+                "default_vehicle_entrance"
+              ],
+              "postal_code": "60605"
+            }
+          ],
+          "description": "",
+          "facility_type": "lot",
+          "navigation_tip": "Enter this location at 412 S Dearborn. This facility is operated by Buddy's Parking and is located on the West side of Dearborn, just past Congress. The closest intersection is Dearborn and Congress.",
+          "clearance_inches": null,
+          "hours_of_operation": {
+            "periods": [
+              {
+                "day_of_week": "sunday",
+                "start_time_secs": 21600,
+                "end_time_secs": 57600
+              },
+              {
+                "day_of_week": "monday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              },
+              {
+                "day_of_week": "tuesday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              },
+              {
+                "day_of_week": "wednesday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              },
+              {
+                "day_of_week": "thursday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              },
+              {
+                "day_of_week": "friday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              },
+              {
+                "day_of_week": "saturday",
+                "start_time_secs": 21600,
+                "end_time_secs": 72000
+              }
+            ],
+            "always_open": false
+          },
+          "images": [
+            {
+              "id": "3470",
+              "url": "https://res.cloudinary.com/spothero/w_4608,h_3072,x_2304,y_1536,q_50,c_fill,g_xy_center,f_auto/v1412380311/izpckmriktnqpbjybqat.jpg",
+              "alt_text": "412 South Dearborn Street Parking"
+            },
+            {
+              "id": "3471",
+              "url": "https://res.cloudinary.com/spothero/w_4608,h_3072,x_2304,y_1536,q_50,c_fill,g_xy_center,f_auto/v1412380327/bnsefijs3nzea5vqrif9.jpg",
+              "alt_text": "412 South Dearborn Street Parking"
+            },
+            {
+              "id": "3469",
+              "url": "https://res.cloudinary.com/spothero/w_4608,h_3072,x_2347,y_1235,q_50,c_fill,g_xy_center,f_auto/v1412380308/kvknkobjwjwerd8larvb.jpg",
+              "alt_text": "412 South Dearborn Street Parking"
+            }
+          ],
+          "parking_types": [
+            "transient"
+          ],
+          "rating": {
+            "average": 4.149231894659839,
+            "count": 1367
+          },
+          "restrictions": [
+            "For multi-day, 24 hour, or overnight reservations, you may only access your vehicle during the hours of operation. After hours, the gate will be locked."
+          ],
+          "requirements": {
+            "printout": false,
+            "license_plate": true,
+            "phone_number": false
+          },
+          "supported_fee_types": [
+            "blanket_fee"
+          ],
+          "@availability": "https://api.sandbox.spothero.com/v2/search/transient/978"
+        },
+        "transient": {
+          "redemption_instructions": {
+            "drive_up": [
+              {
+                "id": "1001",
+                "illustration": {
+                  "id": "12",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636881/pp3uajdxl5u9lrnak1as.png",
+                  "alt_text": "License Plate"
+                },
+                "text": "<p>Make sure your license plate matches the plate on your Parking Pass. Failure to do so will result in a ticket or tow.</p>"
+              },
+              {
+                "id": "1000",
+                "illustration": {
+                  "id": "7",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636122/b2omz3upgcpjn44cyhjb.png",
+                  "alt_text": "Park Where"
+                },
+                "text": "You may park anywhere that doesn't say \"Reserved\".  If there is an attendant on duty, please show your SpotHero Parking Pass, either printed or on your mobile device.  \n"
+              },
+              {
+                "id": "1002",
+                "illustration": {
+                  "id": "8",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636065/hodnezajkpxuiisu0i4e.png",
+                  "alt_text": "See Ya (Wave)"
+                },
+                "text": "<p>Simply leave when you're ready to go!!</p>"
+              }
+            ]
+          }
+        }
+      },
+      "rates": [
+        {
+          "transient": {
+            "redemption_type": "self_valet_assist",
+            "amenities": [
+              {
+                "type": "wheelchair_accessible",
+                "description": "The facility is wheelchair accessible."
+              },
+              {
+                "type": "paved",
+                "description": "The surface of the facility is solid, such as asphalt or concrete."
+              },
+              {
+                "type": "self_park",
+                "description": "Users may park their own vehicles at this facility."
+              },
+              {
+                "type": "valet",
+                "description": "A valet will park the users vehicle at this facility."
+              }
+            ]
+          },
+          "quote": {
+            "order": [
+              {
+                "facility_id": "978",
+                "starts": "2020-07-29T14:43:38-05:00",
+                "ends": "2020-07-30T14:43:38-05:00",
+                "rate_id": "901",
+                "items": [
+                  {
+                    "price": {
+                      "value": 3400,
+                      "currency_code": "USD"
+                    },
+                    "type": "rental",
+                    "short_description": "Subtotal",
+                    "full_description": ""
+                  },
+                  {
+                    "price": {
+                      "value": 50,
+                      "currency_code": "USD"
+                    },
+                    "type": "blanket_fee",
+                    "short_description": "Service Fee",
+                    "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                  }
+                ],
+                "total_price": {
+                  "value": 3450,
+                  "currency_code": "USD"
+                },
+                "meta": {}
+              }
+            ],
+            "items": [
+              {
+                "price": {
+                  "value": 3400,
+                  "currency_code": "USD"
+                },
+                "type": "rental",
+                "short_description": "Subtotal",
+                "full_description": ""
+              },
+              {
+                "price": {
+                  "value": 50,
+                  "currency_code": "USD"
+                },
+                "type": "blanket_fee",
+                "short_description": "Service Fee",
+                "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+              }
+            ],
+            "total_price": {
+              "value": 3450,
+              "currency_code": "USD"
+            },
+            "advertised_price": {
+              "value": 3400,
+              "currency_code": "USD"
+            },
+            "meta": {
+              "quote_mac": "901",
+              "quote_valid_until": "2020-07-30T14:43:38-05:00",
+              "partner_id": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "distance": {
+        "linear_meters": 212.05866704963435
+      },
+      "facility": {
+        "common": {
+          "id": "8987",
+          "title": "SH Oversize Spot",
+          "addresses": [
+            {
+              "id": "9473",
+              "city": "Chicago",
+              "latitude": 41.8799308,
+              "longitude": -87.6305172,
+              "state": "IL",
+              "street_address": "125 South Clark Street",
+              "time_zone": "America/Chicago",
+              "country": "US",
+              "types": [
+                "physical",
+                "search",
+                "walking_distance",
+                "default_vehicle_entrance"
+              ],
+              "postal_code": "60603"
+            }
+          ],
+          "description": "",
+          "facility_type": "lot",
+          "navigation_tip": "",
+          "clearance_inches": null,
+          "hours_of_operation": {
+            "periods": [],
+            "always_open": true
+          },
+          "images": [
+            {
+              "id": "19745",
+              "url": "https://res.cloudinary.com/spothero/image/upload/w_750,h_500,x_375,y_250,q_50,c_fill,g_xy_center,f_auto/v1577978927/rzm2xqhtgqxfv3isxmyy.jpg",
+              "alt_text": "125 South Clark Street Parking"
+            }
+          ],
+          "parking_types": [
+            "transient"
+          ],
+          "rating": {
+            "average": 5,
+            "count": 7
+          },
+          "restrictions": [],
+          "requirements": {
+            "printout": false,
+            "license_plate": false,
+            "phone_number": false
+          },
+          "supported_fee_types": [
+            "blanket_fee",
+            "oversize_fee"
+          ],
+          "@availability": "https://api.sandbox.spothero.com/v2/search/transient/8987"
+        },
+        "transient": {
+          "redemption_instructions": {
+            "drive_up": [
+              {
+                "id": "37074",
+                "illustration": {
+                  "id": "9",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636043/rc6uuzecbw3nfth0hlky.png",
+                  "alt_text": "Pass Check Attendant"
+                },
+                "text": "Show the valet your SpotHero Parking Pass, either printed or on a mobile device."
+              },
+              {
+                "id": "37075",
+                "illustration": {
+                  "id": "3",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636496/qxzzfxbzzpv9uttohajw.png",
+                  "alt_text": "Valet Give Ticket"
+                },
+                "text": "The valet will hand you a ticket and will park your car. You must have this ticket in order to exit."
+              },
+              {
+                "id": "37076",
+                "illustration": {
+                  "id": "1",
+                  "url": "https://res.cloudinary.com/spothero/image/upload/v1408636831/jxvqbxtqj6tvdvdv0ytj.png",
+                  "alt_text": "Valet Pass Check"
+                },
+                "text": "When you're ready to go, show the valet your ticket and your car will be retrieved."
+              }
+            ]
+          }
+        }
+      },
+      "rates": [
+        {
+          "transient": {
+            "redemption_type": "self",
+            "amenities": [
+              {
+                "type": "in_out",
+                "description": "Users may enter and exit the facility more than one time."
+              },
+              {
+                "type": "self_park",
+                "description": "Users may park their own vehicles at this facility."
+              },
+              {
+                "type": "touchless",
+                "description": "Entering/exiting the facility does not require touching shared surfaces."
+              }
+            ]
+          },
+          "quote": {
+            "order": [
+              {
+                "facility_id": "8987",
+                "starts": "2020-07-29T14:43:38-05:00",
+                "ends": "2020-07-29T22:43:38-05:00",
+                "rate_id": "7672",
+                "items": [
+                  {
+                    "price": {
+                      "value": 1049,
+                      "currency_code": "USD"
+                    },
+                    "type": "rental",
+                    "short_description": "Subtotal",
+                    "full_description": ""
+                  },
+                  {
+                    "price": {
+                      "value": 50,
+                      "currency_code": "USD"
+                    },
+                    "type": "blanket_fee",
+                    "short_description": "Service Fee",
+                    "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                  }
+                ],
+                "total_price": {
+                  "value": 1099,
+                  "currency_code": "USD"
+                },
+                "meta": {}
+              }
+            ],
+            "items": [
+              {
+                "price": {
+                  "value": 1049,
+                  "currency_code": "USD"
+                },
+                "type": "rental",
+                "short_description": "Subtotal",
+                "full_description": ""
+              },
+              {
+                "price": {
+                  "value": 50,
+                  "currency_code": "USD"
+                },
+                "type": "blanket_fee",
+                "short_description": "Service Fee",
+                "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+              }
+            ],
+            "total_price": {
+              "value": 1099,
+              "currency_code": "USD"
+            },
+            "advertised_price": {
+              "value": 1049,
+              "currency_code": "USD"
+            },
+            "meta": {
+              "quote_mac": "7672",
+              "quote_valid_until": "2020-07-29T22:43:38-05:00",
+              "partner_id": ""
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "@next": "https://api.sandbox.spothero.com/v2/search/transient?after=8987&;lat=41.8781&lon=-87.6298&max_distance_meters=1609.34&page_size=5&starts=2020-07-29T19%3A38%3A50Z"
+}

--- a/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetTransientFacilitiesRequestTests.swift
+++ b/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetTransientFacilitiesRequestTests.swift
@@ -1,0 +1,59 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+@testable import SpotHeroAPINext
+import XCTest
+
+private protocol SearchGetTransientFacilitiesRequestTests: APITestCase {
+    func testGetTransientFacilitiesSucceeds()
+}
+
+private extension SearchGetTransientFacilitiesRequestTests {
+    /// Attempts to fetch a list of transient facilities, expecting success
+    func getTransientFacilities(parameters: SearchGetTransientFacilitiesRequest.Parameters,
+                                file: StaticString = #file,
+                                line: UInt = #line) {
+        let request = SearchGetTransientFacilitiesRequest(client: Self.newNetworkClient(for: .craig))
+        let expectation = self.expectation(description: "Fetched transient facilities.")
+        
+        request(parameters: parameters) { result in
+            switch result {
+            case let .success(response):
+                // WIP: Better tests
+                XCTAssertGreaterThan(response.results.count, 0, file: file, line: line)
+            case let .failure(error):
+                XCTFail("Error fetching facilities! \(error.localizedDescription)", file: file, line: line)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: Self.timeout)
+    }
+}
+
+// swiftlint:disable:next type_name
+final class SearchGetTransientFacilitiesRequestLiveTests: LiveAPITestCase, SearchGetTransientFacilitiesRequestTests {
+    func testGetTransientFacilitiesSucceeds() {
+        self.getTransientFacilities(parameters: .init(latitude: TestData.latitude,
+                                                      longitude: TestData.longitude,
+                                                      startDate: TestData.startDate))
+    }
+}
+
+// swiftlint:disable:next type_name
+final class SearchGetTransientFacilitiesRequestMockTests: MockAPITestCase, SearchGetTransientFacilitiesRequestTests {
+    func testGetTransientFacilitiesSucceeds() {
+        self.stub(SearchGetTransientFacilitiesRequest.self,
+                  with: .apiMockFile("CRAIG/Search/get_transient_facilities.json"))
+        
+        self.getTransientFacilities(parameters: .init(latitude: TestData.latitude,
+                                                      longitude: TestData.longitude,
+                                                      startDate: TestData.startDate))
+    }
+}
+
+private struct TestData {
+    static let latitude: Double = 41.8781 // Chicago Latitude
+    static let longitude: Double = -87.6298 // Chicago Longitude
+    static let startDate = Date() // Today
+}


### PR DESCRIPTION
**Issue Link**
IOS-2256

**Description**
- Added `SearchGetTransientFacilitiesRequest` following the paradigm from previous POCs.
- Added `Parameters` struct within this request for strongly typed parameter enforcement. It adheres to the `asParameterDictionary` function for making network requests simple.
- Added `touchless` amenity which didn't exist before! Hooray.
- Added mock file for the request.

Similar to the previous PR, no real testing of the actual search response included just yet, this is only meant to test the deserialization. Testing the full responses will likely involve mirroring the `SpotHeroAPI` v1 tests in the future.
