### PR TITLE
IOS-2257: Implemented searchTransientFacilityParking GET Request

### DIFF
--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -68,13 +68,13 @@ class NetworkClient {
     /// - Parameter completion: The completion block to call when the request is completed.
     /// - Returns: The `URLSessionTask` for the request.
     @discardableResult
-    private func request<T: Decodable>(route: URLConvertible,
-                                       method: HTTPMethod,
-                                       parameters: ParameterDictionaryConvertible? = nil,
-                                       headers: HTTPHeaderDictionaryConvertible? = nil,
-                                       encoding: ParameterEncoding? = nil,
-                                       decoder: JSONDecoder = .spotHeroAPI,
-                                       completion: RequestCompletion<T>? = nil) -> URLSessionTask? {
+    func request<T: Decodable>(route: URLConvertible,
+                               method: HTTPMethod,
+                               parameters: ParameterDictionaryConvertible? = nil,
+                               headers: HTTPHeaderDictionaryConvertible? = nil,
+                               encoding: ParameterEncoding? = nil,
+                               decoder: JSONDecoder = .spotHeroAPI,
+                               completion: RequestCompletion<T>? = nil) -> URLSessionTask? {
         // Prepend the base URL to the monolith route path
         let url: URLConvertible = "\(self.baseURL)/\(route)"
             // and strip any double-slashes we find that aren't proceeded by a colon (indicating a scheme)

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -5,7 +5,7 @@ import UtilityBeltNetworking
 
 /// Represents a request for fetching transient facilities.
 ///
-/// - See [searchTransientParking](https://s3.amazonaws.com/spothe.ro/craig-v2-api.html#operation/searchTransientParking).
+/// - See [searchTransientFacilityParking](https://s3.amazonaws.com/spothe.ro/craig-v2-api.html#operation/searchTransientFacilityParking).
 public struct SearchGetTransientFacilityRequest: RequestDefining {
     public typealias ResponseModel = TransientFacilitySearchResponse
     

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -19,9 +19,9 @@ public struct SearchGetTransientFacilityRequest: RequestDefining {
     }
     
     @discardableResult
-    func callAsFunction(withID facilityID: Int,
-                        parameters: Parameters? = nil,
-                        completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+    public func callAsFunction(withID facilityID: Int,
+                               parameters: Parameters? = nil,
+                               completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
         return self.client.request(
             route: "\(Self.route)/\(facilityID)",
             method: Self.method,
@@ -33,7 +33,7 @@ public struct SearchGetTransientFacilityRequest: RequestDefining {
 
 // MARK: - Parameters
 
-extension SearchGetTransientFacilityRequest {
+public extension SearchGetTransientFacilityRequest {
     /// Represents the query parameters used for fetching transient facilities.
     struct Parameters: Encodable {
         private enum CodingKeys: String, CodingKey {
@@ -45,20 +45,20 @@ extension SearchGetTransientFacilityRequest {
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
         /// If this parameter is not provided, results will be generated from the time at which the request was received.
-        let startDate: Date?
+        private let startDate: Date?
         
         /// End datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
         /// If this parameter is not provided, results will be generated for 3 hours after the start time.
-        let endDate: Date?
+        private let endDate: Date?
         
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
-        let isOversize: Bool?
+        private let isOversize: Bool?
         
-        init(startDate: Date? = nil,
-             endDate: Date? = nil,
-             isOversize: Bool? = nil) {
+        public init(startDate: Date? = nil,
+                    endDate: Date? = nil,
+                    isOversize: Bool? = nil) {
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
@@ -67,7 +67,7 @@ extension SearchGetTransientFacilityRequest {
 }
 
 extension SearchGetTransientFacilityRequest.Parameters: ParameterDictionaryConvertible {
-    func asParameterDictionary() -> [String: Any]? {
+    public func asParameterDictionary() -> [String: Any]? {
         var parameters: [String: Any] = [:]
         
         if let startDate = self.startDate {

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -1,0 +1,87 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import UtilityBeltNetworking
+
+/// Represents a request for fetching transient facilities.
+///
+/// - See [searchTransientParking](https://s3.amazonaws.com/spothe.ro/craig-v2-api.html#operation/searchTransientParking).
+public struct SearchGetTransientFacilityRequest: RequestDefining {
+    public typealias ResponseModel = TransientFacilitySearchResponse
+    
+    static let method: HTTPMethod = .get
+    static let route = "/v2/search/transient"
+    
+    let client: NetworkClient
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    @discardableResult
+    func callAsFunction(withID facilityID: Int,
+                        parameters: Parameters? = nil,
+                        completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+        return self.client.request(
+            route: "\(Self.route)/\(facilityID)",
+            method: Self.method,
+            parameters: parameters,
+            completion: completion
+        )
+    }
+}
+
+// MARK: - Parameters
+
+extension SearchGetTransientFacilityRequest {
+    /// Represents the query parameters used for fetching transient facilities.
+    struct Parameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case endDate = "ends"
+            case isOversize = "oversize"
+            case startDate = "starts"
+        }
+        
+        /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated from the time at which the request was received.
+        let startDate: Date?
+        
+        /// End datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated for 3 hours after the start time.
+        let endDate: Date?
+        
+        /// Boolean that denotes whether or not the pricing calculated for this vehicle
+        /// will incorporate pricing for an oversize vehicle, if applicable.
+        let isOversize: Bool?
+        
+        init(startDate: Date? = nil,
+             endDate: Date? = nil,
+             isOversize: Bool? = nil) {
+            self.startDate = startDate
+            self.endDate = endDate
+            self.isOversize = isOversize
+        }
+    }
+}
+
+extension SearchGetTransientFacilityRequest.Parameters: ParameterDictionaryConvertible {
+    func asParameterDictionary() -> [String: Any]? {
+        var parameters: [String: Any] = [:]
+        
+        if let startDate = self.startDate {
+            parameters[Self.CodingKeys.startDate.rawValue] = ISO8601DateFormatter().string(from: startDate)
+        }
+        
+        if let endDate = self.endDate {
+            parameters[Self.CodingKeys.endDate.rawValue] = ISO8601DateFormatter().string(from: endDate)
+        }
+        
+        if let isOversize = self.isOversize {
+            parameters[Self.CodingKeys.isOversize.rawValue] = isOversize
+        }
+        
+        return parameters
+    }
+}

--- a/Tests/SpotHeroAPITests/Resources/MockFiles.bundle/CRAIG/Search/get_transient_facilities_2175.json
+++ b/Tests/SpotHeroAPITests/Resources/MockFiles.bundle/CRAIG/Search/get_transient_facilities_2175.json
@@ -1,0 +1,229 @@
+{
+  "result": {
+    "distance": null,
+    "facility": {
+      "common": {
+        "id": "2175",
+        "title": "318 S Federal St. - South Loop Garage",
+        "addresses": [
+          {
+            "id": "2283",
+            "city": "Chicago",
+            "latitude": 41.8776231828,
+            "longitude": -87.6299697423,
+            "state": "IL",
+            "street_address": "318 South Federal Street",
+            "time_zone": "America/Chicago",
+            "country": "US",
+            "types": [
+              "physical",
+              "search",
+              "walking_distance",
+              "default_vehicle_entrance"
+            ],
+            "postal_code": "60604"
+          },
+          {
+            "id": "2284",
+            "city": "Chicago",
+            "latitude": 41.877150308281614,
+            "longitude": -87.62986063957214,
+            "state": "IL",
+            "street_address": "64 West Van Buren Street",
+            "time_zone": "America/Chicago",
+            "country": "US",
+            "types": [
+              "vehicle_entrance"
+            ],
+            "postal_code": "60605"
+          }
+        ],
+        "description": "",
+        "facility_type": "garage",
+        "navigation_tip": "Enter this location at 318 S Federal St. This garage is operated by InterPark. It is located on the west side of S Federal St. between W Jackson Blvd. and W Van Buren St. You may also enter this location at its other entrance, 64 W Van Buren St.",
+        "clearance_inches": 82,
+        "hours_of_operation": {
+          "periods": [],
+          "always_open": true
+        },
+        "images": [
+          {
+            "id": "5200",
+            "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302505/la0i1xbcdxgvdbtozxou.jpg",
+            "alt_text": "318 South Federal Street Parking"
+          },
+          {
+            "id": "7528",
+            "url": "https://res.cloudinary.com/spothero/w_535,h_657,x_267,y_328,q_50,c_fill,g_xy_center,f_auto/v1433973814/m6bkw19hfnp35ntxvqfg.png",
+            "alt_text": "318 South Federal Street Parking"
+          },
+          {
+            "id": "5199",
+            "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302489/ugzqq0ojnpzobffynqj9.jpg",
+            "alt_text": "318 South Federal Street Parking"
+          },
+          {
+            "id": "5198",
+            "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302467/kabrjdjtgne3jnbjrigg.jpg",
+            "alt_text": "318 South Federal Street Parking"
+          },
+          {
+            "id": "5202",
+            "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302529/ywy7jgp78kfg45ylbbgk.jpg",
+            "alt_text": "318 South Federal Street Parking"
+          },
+          {
+            "id": "5201",
+            "url": "https://res.cloudinary.com/spothero/w_4288,h_2848,x_2144,y_1424,q_50,c_fill,g_xy_center,f_auto/v1421302515/agh8987y9rmzvnduipnv.jpg",
+            "alt_text": "318 South Federal Street Parking"
+          }
+        ],
+        "parking_types": [
+          "transient"
+        ],
+        "rating": {
+          "average": 4.602529960053262,
+          "count": 6008
+        },
+        "restrictions": [
+          "Height restriction: 82 inches"
+        ],
+        "requirements": {
+          "printout": false,
+          "license_plate": false,
+          "phone_number": false
+        },
+        "supported_fee_types": [
+          "blanket_fee",
+          "facility_fee"
+        ],
+        "@availability": "https://api.sandbox.spothero.com/v2/search/transient/2175"
+      },
+      "transient": {
+        "redemption_instructions": {
+          "drive_up": [
+            {
+              "id": "39859",
+              "illustration": {
+                "id": "1",
+                "url": "https://res.cloudinary.com/spothero/image/upload/v1408636831/jxvqbxtqj6tvdvdv0ytj.png",
+                "alt_text": "Valet Pass Check"
+              },
+              "text": "<p>When you're ready to go, show the valet your ticket and your car will be retrieved. cherries</p>"
+            },
+            {
+              "id": "39853",
+              "illustration": {
+                "id": "1",
+                "url": "https://res.cloudinary.com/spothero/image/upload/v1408636831/jxvqbxtqj6tvdvdv0ytj.png",
+                "alt_text": "Valet Pass Check"
+              },
+              "text": "<p>When you're ready to go, show the valet your ticket and your car will be retrieved. apples</p>"
+            }
+          ]
+        }
+      }
+    },
+    "rates": [
+      {
+        "transient": {
+          "redemption_type": "self",
+          "amenities": [
+            {
+              "type": "covered",
+              "description": "The facility has a roof over the vehicles."
+            },
+            {
+              "type": "ev",
+              "description": "The facility has EV charging capabilities."
+            },
+            {
+              "type": "attendant",
+              "description": "The facility has staff on-site for assistance and questions."
+            },
+            {
+              "type": "paved",
+              "description": "The surface of the facility is solid, such as asphalt or concrete."
+            },
+            {
+              "type": "self_park",
+              "description": "Users may park their own vehicles at this facility."
+            },
+            {
+              "type": "touchless",
+              "description": "Entering/exiting the facility does not require touching shared surfaces."
+            }
+          ]
+        },
+        "quote": {
+          "order": [
+            {
+              "facility_id": "2175",
+              "starts": "2020-07-29T15:00:26-05:00",
+              "ends": "2020-07-29T18:00:26-05:00",
+              "rate_id": "2088",
+              "items": [
+                {
+                  "price": {
+                    "value": 1575,
+                    "currency_code": "USD"
+                  },
+                  "type": "rental",
+                  "short_description": "Subtotal",
+                  "full_description": ""
+                },
+                {
+                  "price": {
+                    "value": 50,
+                    "currency_code": "USD"
+                  },
+                  "type": "blanket_fee",
+                  "short_description": "Service Fee",
+                  "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+                }
+              ],
+              "total_price": {
+                "value": 1625,
+                "currency_code": "USD"
+              },
+              "meta": {}
+            }
+          ],
+          "items": [
+            {
+              "price": {
+                "value": 1575,
+                "currency_code": "USD"
+              },
+              "type": "rental",
+              "short_description": "Subtotal",
+              "full_description": ""
+            },
+            {
+              "price": {
+                "value": 50,
+                "currency_code": "USD"
+              },
+              "type": "blanket_fee",
+              "short_description": "Service Fee",
+              "full_description": "The service fee helps us cover the costs of running our platform and providing services related to your Reservation. For more information, visit our FAQs."
+            }
+          ],
+          "total_price": {
+            "value": 1625,
+            "currency_code": "USD"
+          },
+          "advertised_price": {
+            "value": 1575,
+            "currency_code": "USD"
+          },
+          "meta": {
+            "quote_mac": "2088",
+            "quote_valid_until": "2020-07-29T18:00:26-05:00",
+            "partner_id": ""
+          }
+        }
+      }
+    ]
+  }
+}

--- a/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetTransientFacilityRequestTests.swift
+++ b/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetTransientFacilityRequestTests.swift
@@ -1,0 +1,55 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+@testable import SpotHeroAPINext
+import XCTest
+
+private protocol SearchGetTransientFacilityRequestTests: APITestCase {
+    func testGetTransientFacilitiesSucceeds()
+}
+
+private extension SearchGetTransientFacilityRequestTests {
+    /// Attempts to fetch a list of transient facilities, expecting success
+    func getTransientFacility(withID facilityID: Int,
+                              parameters: SearchGetTransientFacilityRequest.Parameters? = nil,
+                              file: StaticString = #file,
+                              line: UInt = #line) {
+        let request = SearchGetTransientFacilityRequest(client: Self.newNetworkClient(for: .craig))
+        let expectation = self.expectation(description: "Fetched transient facility.")
+        
+        request(withID: facilityID, parameters: parameters) { result in
+            switch result {
+            case let .success(response):
+                // WIP: Better tests
+                XCTAssertNotNil(response, file: file, line: line)
+            case let .failure(error):
+                XCTFail("Error fetching facility! \(error.localizedDescription)", file: file, line: line)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: Self.timeout)
+    }
+}
+
+// swiftlint:disable:next type_name
+final class SearchGetTransientFacilityRequestLiveTests: LiveAPITestCase, SearchGetTransientFacilityRequestTests {
+    func testGetTransientFacilitiesSucceeds() {
+        self.getTransientFacility(withID: TestData.facilityID)
+    }
+}
+
+// swiftlint:disable:next type_name
+final class SearchGetTransientFacilityRequestMockTests: MockAPITestCase, SearchGetTransientFacilityRequestTests {
+    func testGetTransientFacilitiesSucceeds() {
+        self.stub(.get("\(SearchGetTransientFacilityRequest.route)/\(TestData.facilityID)"),
+                  with: .apiMockFile("CRAIG/Search/get_transient_facilities_\(TestData.facilityID).json"))
+        
+        self.getTransientFacility(withID: TestData.facilityID)
+    }
+}
+
+private struct TestData {
+    static let facilityID = 2175
+    static let startDate = Date() // Today
+}


### PR DESCRIPTION
**Issue Link**
IOS-2257

**Description**
- Added `SearchGetTransientFacilityRequest` following the paradigm from previous POCs.
- Added `Parameters` struct within this request for strongly typed parameter enforcement. It adheres to the `asParameterDictionary` function for making network requests simple.
- Added mock file for the request.
- Made the `request` function on `NetworkClient` internal so it could be used in testing. Will need to figure out a smoother way to contain `Route` for a request with path parameters.

Similar to the previous PR, no real testing of the actual search response included just yet, this is only meant to test the deserialization. Testing the full responses will likely involve mirroring the `SpotHeroAPI` v1 tests in the future.