### PR TITLE
IOS-2259: Implemented searchAirportFacilityParking GET Request

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
@@ -1,0 +1,75 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import UtilityBeltNetworking
+
+/// Represents a request for fetching a airport facility.
+///
+/// - See [searchAirportFacilityParking](https://api.spothero.com/v2/docs/#operation/searchAirportFacilityParking).
+public struct SearchGetAirportFacilityRequest: RequestDefining {
+    public typealias ResponseModel = AirportFacilitySearchResponse
+    
+    static let method: HTTPMethod = .get
+    static let route = "/v2/search/airport"
+    
+    let client: NetworkClient
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    @discardableResult
+    public func callAsFunction(withID facilityID: Int,
+                               parameters: Parameters? = nil,
+                               completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+        return self.client.request(
+            route: "\(Self.route)/\(facilityID)",
+            method: Self.method,
+            parameters: parameters,
+            completion: completion
+        )
+    }
+}
+
+// MARK: - Parameters
+
+public extension SearchGetAirportFacilityRequest {
+    /// Represents the query parameters used for fetching a airport facility.
+    struct Parameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case endDate = "ends"
+            case startDate = "starts"
+        }
+        
+        /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated from the time at which the request was received.
+        private let startDate: Date?
+        
+        /// End datetime from to which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated for 3 hours after the start time.
+        private let endDate: Date?
+        
+        public init(startDate: Date? = nil, endDate: Date? = nil) {
+            self.startDate = startDate
+            self.endDate = endDate
+        }
+    }
+}
+
+extension SearchGetAirportFacilityRequest.Parameters: ParameterDictionaryConvertible {
+    public func asParameterDictionary() -> [String: Any]? {
+        var parameters: [String: Any] = [:]
+        
+        if let startDate = self.startDate {
+            parameters[Self.CodingKeys.startDate.rawValue] = ISO8601DateFormatter().string(from: startDate)
+        }
+        
+        if let endDate = self.endDate {
+            parameters[Self.CodingKeys.endDate.rawValue] = ISO8601DateFormatter().string(from: endDate)
+        }
+        
+        return parameters
+    }
+}

--- a/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetAirportFacilityRequestTests.swift
+++ b/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetAirportFacilityRequestTests.swift
@@ -1,0 +1,33 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+@testable import SpotHeroAPINext
+import XCTest
+
+private protocol SearchGetAirportFacilityRequestTests: APITestCase {
+    func testGetAirportFacilitiesSucceeds()
+}
+
+private extension SearchGetAirportFacilityRequestTests {
+    /// Attempts to fetch a list of airport facilities, expecting success
+    func getAirportFacility(withID facilityID: Int,
+                            parameters: SearchGetAirportFacilityRequest.Parameters? = nil,
+                            file: StaticString = #file,
+                            line: UInt = #line) {
+        let request = SearchGetAirportFacilityRequest(client: Self.newNetworkClient(for: .craig))
+        let expectation = self.expectation(description: "Fetched airport facility.")
+        
+        request(withID: facilityID, parameters: parameters) { result in
+            switch result {
+            case let .success(response):
+                // WIP: Better tests
+                XCTAssertNotNil(response, file: file, line: line)
+            case let .failure(error):
+                XCTFail("Error fetching facility! \(error.localizedDescription)", file: file, line: line)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: Self.timeout)
+    }
+}


### PR DESCRIPTION
**Issue Link**
IOS-2259

**Description**
- Added `SearchGetAirportFacilityRequest` following the paradigm from previous POCs.
- Added `Parameters` struct within this request for strongly typed parameter enforcement. It adheres to the `asParameterDictionary` function for making network requests simple.

No mock files or tests yet because Airport is not fully implemented. This is just preparation.