### PR TITLE
IOS-2258: Implemented searchAirportParking GET Request

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
@@ -1,0 +1,92 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import UtilityBeltNetworking
+
+/// Represents a request for fetching airport facilities.
+///
+/// - See [searchAirportParking](https://api.spothero.com/v2/docs/#operation/searchAirportParking).
+public struct SearchGetAirportFacilitiesRequest: RequestDefining {
+    public typealias ResponseModel = AirportFacilitiesSearchResponse
+    
+    static let method: HTTPMethod = .get
+    static let route = "/v2/search/airport"
+    
+    let client: NetworkClient
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    @discardableResult
+    public func callAsFunction(parameters: Parameters,
+                               completion: @escaping RequestCompletion<ResponseModel>) -> URLSessionTask? {
+        return self.client.request(
+            Self.self,
+            parameters: parameters,
+            completion: completion
+        )
+    }
+}
+
+// MARK: - Parameters
+
+public extension SearchGetAirportFacilitiesRequest {
+    /// Represents the query parameters used for fetching airport facilities.
+    struct Parameters: Encodable {
+        private enum CodingKeys: String, CodingKey {
+            case airportCode = "airport"
+            case endDate = "ends"
+            case startDate = "starts"
+            case pageSize = "page_size"
+        }
+        
+        /// IATA airport code used as the origin position.
+        private let airportCode: String
+        
+        /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated from the time at which the request was received.
+        private let startDate: Date?
+        
+        /// End datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
+        /// If a time zone is not specified, the time will be localized to each generated facility's location.
+        /// If this parameter is not provided, results will be generated for 3 hours after the start time.
+        private let endDate: Date?
+        
+        /// The number of results to include in a single page.
+        /// The default is nil (no limit). Must be >= 1, if provided.
+        private let pageSize: Int?
+        
+        init(airportCode: String,
+             startDate: Date? = nil,
+             endDate: Date? = nil,
+             pageSize: Int? = nil) {
+            self.airportCode = airportCode
+            self.startDate = startDate
+            self.endDate = endDate
+            self.pageSize = pageSize
+        }
+    }
+}
+
+extension SearchGetAirportFacilitiesRequest.Parameters: ParameterDictionaryConvertible {
+    public func asParameterDictionary() -> [String: Any]? {
+        var parameters: [String: Any] = [:]
+        parameters[Self.CodingKeys.airportCode.rawValue] = self.airportCode
+        
+        if let startDate = self.startDate {
+            parameters[Self.CodingKeys.startDate.rawValue] = ISO8601DateFormatter().string(from: startDate)
+        }
+        
+        if let endDate = self.endDate {
+            parameters[Self.CodingKeys.endDate.rawValue] = ISO8601DateFormatter().string(from: endDate)
+        }
+        
+        if let pageSize = self.pageSize {
+            parameters[Self.CodingKeys.pageSize.rawValue] = pageSize
+        }
+        
+        return parameters
+    }
+}

--- a/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetAirportFacilitiesRequestTests.swift
+++ b/Tests/SpotHeroAPITests/TestCases/RequestTests/SearchGetAirportFacilitiesRequestTests.swift
@@ -1,0 +1,32 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+@testable import SpotHeroAPINext
+import XCTest
+
+private protocol SearchGetAirportFacilitiesRequestTests: APITestCase {
+    func testGetAirportFacilitiesSucceeds()
+}
+
+private extension SearchGetAirportFacilitiesRequestTests {
+    /// Attempts to fetch a list of airport facilities, expecting success
+    func getAirportFacilities(parameters: SearchGetAirportFacilitiesRequest.Parameters,
+                              file: StaticString = #file,
+                              line: UInt = #line) {
+        let request = SearchGetAirportFacilitiesRequest(client: Self.newNetworkClient(for: .craig))
+        let expectation = self.expectation(description: "Fetched airport facilities.")
+        
+        request(parameters: parameters) { result in
+            switch result {
+            case let .success(response):
+                // WIP: Better tests
+                XCTAssertGreaterThan(response.results.count, 0, file: file, line: line)
+            case let .failure(error):
+                XCTFail("Error fetching facilities! \(error.localizedDescription)", file: file, line: line)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: Self.timeout)
+    }
+}


### PR DESCRIPTION
**Issue Link**
IOS-2258

**Description**
- Added `SearchGetAirportFacilitiesRequest` following the paradigm from previous POCs.
- Added `Parameters` struct within this request for strongly typed parameter enforcement. It adheres to the `asParameterDictionary` function for making network requests simple.

No mock files or tests yet because Airport is not fully implemented. This is just preparation.