### PR TITLE
Reverted analytics_id to fingerprint

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
@@ -41,7 +41,7 @@ public extension SearchGetAirportFacilitiesRequest {
             case pageSize = "page_size"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -64,7 +64,7 @@ public extension SearchGetAirportFacilitiesRequest {
         private let pageSize: Int?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -79,7 +79,7 @@ public extension SearchGetAirportFacilitiesRequest {
             self.pageSize = pageSize
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }

--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
@@ -41,7 +41,7 @@ public extension SearchGetAirportFacilityRequest {
             case startDate = "starts"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -57,7 +57,7 @@ public extension SearchGetAirportFacilityRequest {
         private let endDate: Date?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -68,7 +68,7 @@ public extension SearchGetAirportFacilityRequest {
             self.endDate = endDate
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }

--- a/Sources/SpotHeroAPI/Search/Common/Models/FacilityRating.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/FacilityRating.swift
@@ -4,7 +4,7 @@
 public struct FacilityRating: Codable {
     /// Average rating from 0 to 5.
     /// `nil` implies that the rating has not yet been calculated.
-    public let rating: Double?
+    public let average: Double?
     
     /// Number of ratings.
     public let count: Int

--- a/Sources/SpotHeroAPI/Search/Common/Protocols/SearchTracking.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Protocols/SearchTracking.swift
@@ -24,4 +24,11 @@ public struct SearchTrackingParameters: SearchTracking {
     public var analyticsID: String?
     public var searchID: String?
     public var sessionID: String?
+    
+    public init(actionID: String?, analyticsID: String?, searchID: String?, sessionID: String?) {
+        self.actionID = actionID
+        self.analyticsID = analyticsID
+        self.searchID = searchID
+        self.sessionID = sessionID
+    }
 }

--- a/Sources/SpotHeroAPI/Search/Common/Protocols/SearchTracking.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Protocols/SearchTracking.swift
@@ -8,7 +8,7 @@ protocol SearchTracking: Encodable {
     var actionID: String? { get }
 
     /// An identifier that represents a user across various analytics services. (eg. Segment, MixPanel, Optimizely, etc.)
-    var analyticsID: String? { get }
+    var fingerprint: String? { get }
 
     /// An identifier that represents each distinct search a user performs for parking.
     /// If a user changes the search text, timeframe, amenities, parking type, or any other value, a new search ID should be issued.
@@ -21,13 +21,13 @@ protocol SearchTracking: Encodable {
 /// A convenience struct for passing around Search Tracking parameters.
 public struct SearchTrackingParameters: SearchTracking {
     public var actionID: String?
-    public var analyticsID: String?
+    public var fingerprint: String?
     public var searchID: String?
     public var sessionID: String?
     
-    public init(actionID: String?, analyticsID: String?, searchID: String?, sessionID: String?) {
+    public init(actionID: String?, fingerprint: String?, searchID: String?, sessionID: String?) {
         self.actionID = actionID
-        self.analyticsID = analyticsID
+        self.fingerprint = fingerprint
         self.searchID = searchID
         self.sessionID = sessionID
     }

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -37,9 +37,9 @@ public extension SearchGetMonthlyFacilitiesRequest {
         private enum CodingKeys: String, CodingKey {
             case latitude = "lat"
             case longitude = "lon"
+            case startDate = "starts"
             case maxDistanceMeters = "max_distance_meters"
             case pageSize = "page_size"
-            case startDate = "starts"
             
             case actionID = "action_id"
             case fingerprint

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -37,9 +37,9 @@ public extension SearchGetMonthlyFacilitiesRequest {
         private enum CodingKeys: String, CodingKey {
             case latitude = "lat"
             case longitude = "lon"
-            case startDate = "starts"
             case maxDistanceMeters = "max_distance_meters"
             case pageSize = "page_size"
+            case startDate = "starts"
             
             case actionID = "action_id"
             case fingerprint

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -42,7 +42,7 @@ public extension SearchGetMonthlyFacilitiesRequest {
             case pageSize = "page_size"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -66,7 +66,7 @@ public extension SearchGetMonthlyFacilitiesRequest {
         private let pageSize: Int?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -83,7 +83,7 @@ public extension SearchGetMonthlyFacilitiesRequest {
             self.pageSize = pageSize
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
@@ -40,7 +40,7 @@ public extension SearchGetMonthlyFacilityRequest {
             case startDate = "starts"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -50,7 +50,7 @@ public extension SearchGetMonthlyFacilityRequest {
         private let startDate: Date?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -59,7 +59,7 @@ public extension SearchGetMonthlyFacilityRequest {
             self.startDate = startDate
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -44,7 +44,7 @@ public extension SearchGetTransientFacilitiesRequest {
             case pageSize = "page_size"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -78,7 +78,7 @@ public extension SearchGetTransientFacilitiesRequest {
         private let pageSize: Int?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -99,7 +99,7 @@ public extension SearchGetTransientFacilitiesRequest {
             self.pageSize = pageSize
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -42,7 +42,7 @@ public extension SearchGetTransientFacilityRequest {
             case startDate = "starts"
             
             case actionID = "action_id"
-            case analyticsID = "analytics_id"
+            case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
         }
@@ -62,7 +62,7 @@ public extension SearchGetTransientFacilityRequest {
         private let isOversize: Bool?
         
         let actionID: String?
-        let analyticsID: String?
+        let fingerprint: String?
         let searchID: String?
         let sessionID: String?
         
@@ -75,7 +75,7 @@ public extension SearchGetTransientFacilityRequest {
             self.isOversize = isOversize
             
             self.actionID = searchTracking?.actionID
-            self.analyticsID = searchTracking?.analyticsID
+            self.fingerprint = searchTracking?.fingerprint
             self.searchID = searchTracking?.searchID
             self.sessionID = searchTracking?.sessionID
         }


### PR DESCRIPTION
**Description**
- `analytics_id` change never went through, so I reverted this back to `fingerprint`.
- Added a public initializer to the `SearchTrackingParameters` struct.