### PR TITLE
IOS-2334: Added origin_lat and origin_lon support

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
@@ -37,8 +37,8 @@ public extension SearchGetAirportFacilitiesRequest {
         private enum CodingKeys: String, CodingKey {
             case airportCode = "airport"
             case endDate = "ends"
-            case startDate = "starts"
             case pageSize = "page_size"
+            case startDate = "starts"
             
             case actionID = "action_id"
             case analyticsID = "analytics_id"

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -38,8 +38,6 @@ public extension SearchGetMonthlyFacilitiesRequest {
             case latitude = "lat"
             case longitude = "lon"
             case maxDistanceMeters = "max_distance_meters"
-            case originLatitude = "origin_lat"
-            case originLongitude = "origin_lon"
             case pageSize = "page_size"
             case startDate = "starts"
             
@@ -54,18 +52,6 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
         private let longitude: Double
-        
-        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
-        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
-        /// Must be specified with `originLongitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
-        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin latitude must be in [-90, 90].
-        private let originLatitude: Double?
-        
-        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
-        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
-        /// Must be specified with `originLatitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
-        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
-        private let originLongitude: Double?
         
         /// Start date from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DD.
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
@@ -86,16 +72,12 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         public init(latitude: Double,
                     longitude: Double,
-                    originLatitude: Double? = nil,
-                    originLongitude: Double? = nil,
                     startDate: Date? = nil,
                     maxDistanceMeters: Int? = nil,
                     pageSize: Int? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude
             self.longitude = longitude
-            self.originLatitude = originLatitude
-            self.originLongitude = originLongitude
             self.startDate = startDate
             self.maxDistanceMeters = maxDistanceMeters
             self.pageSize = pageSize

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -37,9 +37,11 @@ public extension SearchGetMonthlyFacilitiesRequest {
         private enum CodingKeys: String, CodingKey {
             case latitude = "lat"
             case longitude = "lon"
-            case startDate = "starts"
             case maxDistanceMeters = "max_distance_meters"
+            case originLatitude = "origin_lat"
+            case originLongitude = "origin_lon"
             case pageSize = "page_size"
+            case startDate = "starts"
             
             case actionID = "action_id"
             case analyticsID = "analytics_id"
@@ -52,6 +54,18 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
         private let longitude: Double
+        
+        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLongitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin latitude must be in [-90, 90].
+        private let originLatitude: Double?
+        
+        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLatitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
+        private let originLongitude: Double?
         
         /// Start date from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DD.
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
@@ -72,12 +86,16 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         public init(latitude: Double,
                     longitude: Double,
+                    originLatitude: Double? = nil,
+                    originLongitude: Double? = nil,
                     startDate: Date? = nil,
                     maxDistanceMeters: Int? = nil,
                     pageSize: Int? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude
             self.longitude = longitude
+            self.originLatitude = originLatitude
+            self.originLongitude = originLongitude
             self.startDate = startDate
             self.maxDistanceMeters = maxDistanceMeters
             self.pageSize = pageSize

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -36,12 +36,14 @@ public extension SearchGetTransientFacilitiesRequest {
     struct Parameters: Encodable, SearchTracking, ParameterDictionaryConvertible {
         private enum CodingKeys: String, CodingKey {
             case endDate = "ends"
+            case isOversize = "oversize"
             case latitude = "lat"
             case longitude = "lon"
-            case isOversize = "oversize"
-            case startDate = "starts"
             case maxDistanceMeters = "max_distance_meters"
+            case originLatitude = "origin_lat"
+            case originLongitude = "origin_lon"
             case pageSize = "page_size"
+            case startDate = "starts"
             
             case actionID = "action_id"
             case analyticsID = "analytics_id"
@@ -54,6 +56,18 @@ public extension SearchGetTransientFacilitiesRequest {
         
         /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
         private let longitude: Double
+        
+        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLongitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin latitude must be in [-90, 90].
+        private let originLatitude: Double?
+        
+        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLatitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
+        private let originLongitude: Double?
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
@@ -84,6 +98,8 @@ public extension SearchGetTransientFacilitiesRequest {
         
         public init(latitude: Double,
                     longitude: Double,
+                    originLatitude: Double? = nil,
+                    originLongitude: Double? = nil,
                     startDate: Date? = nil,
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
@@ -92,6 +108,8 @@ public extension SearchGetTransientFacilitiesRequest {
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude
             self.longitude = longitude
+            self.originLatitude = originLatitude
+            self.originLongitude = originLongitude
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize


### PR DESCRIPTION
**Issue Link**
IOS-2334

**Description**
- Added the `origin_lat` and `origin_lon` parameters to the `GetTransientFacilitiesRequest` struct.
- Adjusted order of `CodingKeys` for various requests.
