### PR TITLE
IOS-2612: Added cancellation information to Transient facility

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
@@ -1,0 +1,22 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+public extension TransientFacilityAttributes {
+    /// This object contains all fields relevant to a facility’s cancellation policy.
+    struct Cancellation: Codable {
+        private enum CodingKeys: String, CodingKey {
+            case allowedByCustomer = "allowed_by_customer"
+            case allowedBySpotHeroCustomerService = "allowed_by_spothero_customer_service"
+            case minutes
+        }
+        
+        /// Whether or not the reservation can be cancelled by the customer.
+        public let allowedByCustomer: Bool
+        
+        /// Whether or not the reservation can be cancelled by SpotHero’s customer service team. Will always be `true` when `allowedByCustomer` is `true`.
+        public let allowedBySpotHeroCustomerService: Bool
+        
+        /// The number of minutes before a reservation starts at which point cancellation is no longer allowed.
+        /// (e.g. When `cancellation.minutes = 60`, cancellations are allowed up until an hour before the reservation start time.)
+        public let minutes: Int
+    }
+}

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
@@ -1,7 +1,7 @@
 // Copyright © 2020 SpotHero, Inc. All rights reserved.
 
 public extension TransientFacilityAttributes {
-    /// This object contains all fields relevant to a facility’s cancellation policy.
+    /// Contains all fields relevant to a facility’s cancellation policy.
     struct Cancellation: Codable {
         private enum CodingKeys: String, CodingKey {
             case allowedByCustomer = "allowed_by_customer"

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+Cancellation.swift
@@ -12,7 +12,8 @@ public extension TransientFacilityAttributes {
         /// Whether or not the reservation can be cancelled by the customer.
         public let allowedByCustomer: Bool
         
-        /// Whether or not the reservation can be cancelled by SpotHero’s customer service team. Will always be `true` when `allowedByCustomer` is `true`.
+        /// Whether or not the reservation can be cancelled by SpotHero’s customer service team.
+        /// Will always be `true` when `allowedByCustomer` is `true`.
         public let allowedBySpotHeroCustomerService: Bool
         
         /// The number of minutes before a reservation starts at which point cancellation is no longer allowed.

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
@@ -3,8 +3,12 @@
 /// Represents facility information only applicable within the transient context.
 public struct TransientFacilityAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
+        case cancellation
         case redemptionInstructions = "redemption_instructions"
     }
+    
+    /// Contains all fields relevant to a facility’s cancellation policy.
+    public let cancellation: Cancellation
     
     /// Information concerning the redemption process for customers who park at a facility.
     public let redemptionInstructions: TransientRedemptionInstructions


### PR DESCRIPTION
**Issue Link**
IOS-2612

**Description**
Added new `cancellation` object to `TransientFacilityAttributes`, based on the contract documented [here](https://spothero.atlassian.net/wiki/spaces/SEAR/pages/1637712304/Search+Transient+V2+Cancellation+Allowed+API+Contract)
