### PR TITLE
IOS-2613: Added is_commuter_card_eligible property to Transient facility

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
@@ -3,8 +3,12 @@
 /// Represents facility information only applicable within the transient context.
 public struct TransientFacilityAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
+        case isCommutedCardEligible = "is_commuter_card_eligible"
         case redemptionInstructions = "redemption_instructions"
     }
+    
+    /// Indicates whether a commuter benefits cards is eligible to be used at this facility for the work location supplied on the request.
+    public let isCommutedCardEligible: Bool
     
     /// Information concerning the redemption process for customers who park at a facility.
     public let redemptionInstructions: TransientRedemptionInstructions

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -71,10 +71,10 @@ public extension SearchGetTransientFacilitiesRequest {
         /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
         private let originLongitude: Double?
         
-        /// This represents the work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
+        /// The work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
         private let workLatitude: Double?
         
-        /// This represents the work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
+        /// The work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
         private let workLongitude: Double?
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -44,6 +44,8 @@ public extension SearchGetTransientFacilitiesRequest {
             case originLongitude = "origin_lon"
             case pageSize = "page_size"
             case startDate = "starts"
+            case workLatitude = "work_lat"
+            case workLongitude = "work_lon"
             
             case actionID = "action_id"
             case fingerprint
@@ -68,6 +70,12 @@ public extension SearchGetTransientFacilitiesRequest {
         /// Must be specified with `originLatitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
         /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
         private let originLongitude: Double?
+        
+        /// This represents the work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
+        private let workLatitude: Double?
+        
+        /// This represents the work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
+        private let workLongitude: Double?
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
         /// If a time zone is not specified, the time will be localized to each generated facility's location.
@@ -100,6 +108,8 @@ public extension SearchGetTransientFacilitiesRequest {
                     longitude: Double,
                     originLatitude: Double? = nil,
                     originLongitude: Double? = nil,
+                    workLatitude: Double? = nil,
+                    workLongitude: Double? = nil,
                     startDate: Date? = nil,
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
@@ -110,6 +120,8 @@ public extension SearchGetTransientFacilitiesRequest {
             self.longitude = longitude
             self.originLatitude = originLatitude
             self.originLongitude = originLongitude
+            self.workLatitude = workLatitude
+            self.workLongitude = workLongitude
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize


### PR DESCRIPTION
**Issue Link**
IOS-2613

**Description**
- Added `is_commuter_card_eligible` property to `TransientFacilityAttributes`.
- Added the `work_lat` and `work_lon` request parameters to `SearchGetTransientFacilitiesRequest.Parameters`.

Both items are based on the contract documented [here](https://spothero.atlassian.net/wiki/spaces/SEAR/pages/1636794577/Search+Transient+V2+Commuter+Card+Benefits+API+Contract+-+Short+Term)
