### PR TITLE
IOS-2615: Added Amenity.displayName

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Models/Amenity.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/Amenity.swift
@@ -4,11 +4,15 @@
 public struct Amenity: Codable {
     private enum CodingKeys: String, CodingKey {
         case description
+        case displayName = "display_name"
         case type
     }
     
     /// Long-form description of the amenity type.
     public let description: String
+    
+    /// The display name for the amenity to be shown to users.
+    public let displayName: String
     
     /// A value which uniquely distinguishes a type of amenity at a parking spot.
     public let type: AmenityType


### PR DESCRIPTION
**Issue Link**
IOS-2615

**Description**
Added the `display_name` property to `Amenity` per [this PR](https://github.com/spothero/craig/pull/326/files).
