### PR TITLE
IOS-2614: Added Early Bird information to the Transient facility

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
@@ -1,11 +1,30 @@
 // Copyright © 2020 SpotHero, Inc. All rights reserved.
 
+import Foundation
+
 public extension TransientFacilityAttributes {
     /// Contains all fields relevant to a facility’s cancellation policy.
     struct EarlyBird: Codable {
         private enum CodingKeys: String, CodingKey {
             case description
-            case enterPriod = "enter_period"
+            case enterPeriod = "enter_period"
         }
+        
+        /// The human readable description of the early bird rate.
+        public let description: String
+        
+        /// Store the enter start/end times for the early bird rate.
+        public let enterPeriod: EnterPeriod
+    }
+}
+
+public extension TransientFacilityAttributes.EarlyBird {
+    /// Store the enter start/end times for the early bird rate.
+    struct EnterPeriod: Codable {
+        /// The enter start time for the early bird rate in the format XX:XX AM/PM with leading 0’s removed.
+        public let starts: Date
+        
+        /// The enter end time for the early bird rate in the format XX:XX AM/PM with leading 0’s removed.
+        public let ends: Date
     }
 }

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
@@ -22,9 +22,9 @@ public extension TransientFacilityAttributes.EarlyBird {
     /// Store the enter start/end times for the early bird rate.
     struct EnterPeriod: Codable {
         /// The enter start time for the early bird rate in the format XX:XX AM/PM with leading 0’s removed.
-        public let starts: Date
+        public let starts: String
         
         /// The enter end time for the early bird rate in the format XX:XX AM/PM with leading 0’s removed.
-        public let ends: Date
+        public let ends: String
     }
 }

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes+EarlyBird.swift
@@ -1,0 +1,11 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+public extension TransientFacilityAttributes {
+    /// Contains all fields relevant to a facility’s cancellation policy.
+    struct EarlyBird: Codable {
+        private enum CodingKeys: String, CodingKey {
+            case description
+            case enterPriod = "enter_period"
+        }
+    }
+}

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
@@ -4,12 +4,17 @@
 public struct TransientFacilityAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
         case cancellation
+        case earlyBird = "early_bird"
         case isCommutedCardEligible = "is_commuter_card_eligible"
         case redemptionInstructions = "redemption_instructions"
     }
     
     /// Contains all fields relevant to a facility’s cancellation policy.
     public let cancellation: Cancellation
+    
+    /// Stores rate data specific to the early bird rate, if applicable.
+    /// If the returned rate does not represent an early bird rate, this object will be `nil`.
+    public let earlyBird: EarlyBird
     
     /// Indicates whether a commuter benefits cards is eligible to be used at this facility for the work location supplied on the request.
     public let isCommutedCardEligible: Bool

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
@@ -14,7 +14,7 @@ public struct TransientFacilityAttributes: Codable {
     
     /// Stores rate data specific to the early bird rate, if applicable.
     /// If the returned rate does not represent an early bird rate, this object will be `nil`.
-    public let earlyBird: EarlyBird
+    public let earlyBird: EarlyBird?
     
     /// Indicates whether a commuter benefits cards is eligible to be used at this facility for the work location supplied on the request.
     public let isCommutedCardEligible: Bool


### PR DESCRIPTION
**Issue Link**
IOS-2614

**Description**
Added the `early_bird` property to `facility.transient` per the documentation [here](https://spothero.atlassian.net/wiki/spaces/SEAR/pages/1640071211/Search+Transient+V2+Early+Bird+Rate+Fields+API+Contract).
