### PR TITLE
Moving cancellation to match change in spec

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
@@ -4,6 +4,7 @@
 public struct CommonFacilityAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
         case addresses
+        case cancellation
         case clearanceInches = "clearance_inches"
         case description
         case facilityType = "facility_type"
@@ -60,4 +61,7 @@ public struct CommonFacilityAttributes: Codable {
     
     /// An array defining the supported fee types at the facility.
     public let supportedFeeTypes: [FacilityFee]
+    
+    /// Contains all fields relevant to a facility’s cancellation policy.
+    public let cancellation: Cancellation
 }

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityAttributes.swift
@@ -3,13 +3,9 @@
 /// Represents facility information only applicable within the transient context.
 public struct TransientFacilityAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
-        case cancellation
         case isCommutedCardEligible = "is_commuter_card_eligible"
         case redemptionInstructions = "redemption_instructions"
     }
-    
-    /// Contains all fields relevant to a facility’s cancellation policy.
-    public let cancellation: Cancellation
     
     /// Indicates whether a commuter benefits cards is eligible to be used at this facility for the work location supplied on the request.
     public let isCommutedCardEligible: Bool


### PR DESCRIPTION
**Description**
`cancellation` is moving from `facility.transient` to `facility.common` since it applies across all verticals.
