### PR TITLE
Added origin_lat and origin_lon to monthly search request

### DIFF
--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -38,6 +38,8 @@ public extension SearchGetMonthlyFacilitiesRequest {
             case latitude = "lat"
             case longitude = "lon"
             case maxDistanceMeters = "max_distance_meters"
+            case originLatitude = "origin_lat"
+            case originLongitude = "origin_lon"
             case pageSize = "page_size"
             case startDate = "starts"
             
@@ -52,6 +54,18 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         /// Longitude in decimal degrees of origin from where the search will be performed. Longitude must be in [-180, 180].
         private let longitude: Double
+        
+        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLongitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin latitude must be in [-90, 90].
+        private let originLatitude: Double?
+        
+        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLatitude` parameter, if applicable. If `originLatitude` and `originLongitude` are not populated,
+        /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
+        private let originLongitude: Double?
         
         /// Start date from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DD.
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
@@ -72,12 +86,16 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         public init(latitude: Double,
                     longitude: Double,
+                    originLatitude: Double? = nil,
+                    originLongitude: Double? = nil,
                     startDate: Date? = nil,
                     maxDistanceMeters: Int? = nil,
                     pageSize: Int? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude
             self.longitude = longitude
+            self.originLatitude = originLatitude
+            self.originLongitude = originLongitude
             self.startDate = startDate
             self.maxDistanceMeters = maxDistanceMeters
             self.pageSize = pageSize


### PR DESCRIPTION
**Description**
Copied over the `originLatitude` and `originLongitude` properties from the Transient version of this request, now that Search V2 Monthly has these properties.