### PR TITLE
Added work_lat and work_lon to monthly search request

### DIFF
--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -42,6 +42,8 @@ public extension SearchGetMonthlyFacilitiesRequest {
             case originLongitude = "origin_lon"
             case pageSize = "page_size"
             case startDate = "starts"
+            case workLatitude = "work_lat"
+            case workLongitude = "work_lon"
             
             case actionID = "action_id"
             case fingerprint
@@ -88,6 +90,8 @@ public extension SearchGetMonthlyFacilitiesRequest {
                     longitude: Double,
                     originLatitude: Double? = nil,
                     originLongitude: Double? = nil,
+                    workLatitude: Double? = nil,
+                    workLongitude: Double? = nil,
                     startDate: Date? = nil,
                     maxDistanceMeters: Int? = nil,
                     pageSize: Int? = nil,
@@ -96,6 +100,8 @@ public extension SearchGetMonthlyFacilitiesRequest {
             self.longitude = longitude
             self.originLatitude = originLatitude
             self.originLongitude = originLongitude
+            self.workLatitude = workLatitude
+            self.workLongitude = workLongitude
             self.startDate = startDate
             self.maxDistanceMeters = maxDistanceMeters
             self.pageSize = pageSize

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -69,6 +69,12 @@ public extension SearchGetMonthlyFacilitiesRequest {
         /// result distances are calculated from the required `latitude` and `longitude` parameters. Origin longitude must be in [-180, 180].
         private let originLongitude: Double?
         
+        /// The work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
+        private let workLatitude: Double?
+        
+        /// The work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
+        private let workLongitude: Double?
+        
         /// Start date from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DD.
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
         private let startDate: Date?

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
@@ -51,6 +51,12 @@ public extension SearchGetMonthlyFacilityRequest {
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
         private let startDate: Date?
         
+        /// The work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
+        private let workLatitude: Double?
+        
+        /// The work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
+        private let workLongitude: Double?
+        
         let actionID: String?
         let fingerprint: String?
         let searchID: String?

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
@@ -38,6 +38,8 @@ public extension SearchGetMonthlyFacilityRequest {
     struct Parameters: Encodable, SearchTracking, ParameterDictionaryConvertible {
         private enum CodingKeys: String, CodingKey {
             case startDate = "starts"
+            case workLatitude = "work_lat"
+            case workLongitude = "work_lon"
             
             case actionID = "action_id"
             case fingerprint
@@ -55,8 +57,12 @@ public extension SearchGetMonthlyFacilityRequest {
         let sessionID: String?
         
         public init(startDate: Date? = nil,
+                    workLatitude: Double? = nil,
+                    workLongitude: Double? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.startDate = startDate
+            self.workLatitude = workLatitude
+            self.workLongitude = workLongitude
             
             self.actionID = searchTracking?.actionID
             self.fingerprint = searchTracking?.fingerprint


### PR DESCRIPTION
**Description**
Implemented the `work_lat` and `work_lon` parameters for Monthly search requests.

Corresponds to the work associated with [SEAR-1253](https://spothero.atlassian.net/browse/SEAR-1253) and [SEAR-1275](https://spothero.atlassian.net/browse/SEAR-1275).
