### PR TITLE
Converted HoursOfOperationPeriod properties to raw strings from enums

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Models/HoursOfOperationPeriod.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/HoursOfOperationPeriod.swift
@@ -11,7 +11,7 @@ public struct HoursOfOperationPeriod: Codable {
     }
     
     /// The first day of week for this period, formatted as a three-letter abbreviation for the day.
-    public let firstDay: DayOfWeek
+    public let firstDay: String
     
     /// The start time for this period, formatted for display.
     public let startTime: String
@@ -20,26 +20,9 @@ public struct HoursOfOperationPeriod: Codable {
     public let endTime: String
     
     /// The last day of week for this period, formatted as a three-letter abbreviation for the day.
-    public let lastDay: DayOfWeek
+    public let lastDay: String
     
     /// The type of hours that this period represents.
-    public let hoursType: HoursType
-}
-
-public extension HoursOfOperationPeriod {
-    /// Represents a day of the week.
-    enum DayOfWeek: String, Codable {
-        case sunday = "Sun"
-        case monday = "Mon"
-        case tuesday = "Tue"
-        case wednesday = "Wed"
-        case thursday = "Thu"
-        case friday = "Fri"
-        case saturday = "Sat"
-    }
-    
-    enum HoursType: String, Codable {
-        case closed
-        case open
-    }
+    /// At the time of writing, the possible values are "open" or "closed".
+    public let hoursType: String
 }

--- a/Sources/SpotHeroAPI/Search/Common/Models/HoursOfOperationPeriod.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/HoursOfOperationPeriod.swift
@@ -22,6 +22,7 @@ public struct HoursOfOperationPeriod: Codable {
     /// The last day of week for this period, formatted as a three-letter abbreviation for the day.
     public let lastDay: String
     
+    // TODO: IOS-2797 - Add link to API documentation showing possible enum values for this property.
     /// The type of hours that this period represents.
     /// At the time of writing, the possible values are "open" or "closed".
     public let hoursType: String

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate+ParkingPass.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate+ParkingPass.swift
@@ -12,6 +12,7 @@ public extension MonthlyRate {
         /// The display name for the parking pass to be shown to users.
         public let displayName: String
         
+        // TODO: IOS-2797 - Add link to API documentation showing possible enum values for this property.
         /// Defines the supported parking pass types
         public let type: String
     }

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate.swift
@@ -66,6 +66,7 @@ public struct MonthlyRate: Codable {
     /// This will be an empty string when there is no associated terms and conditions.
     public let termsAndConditionsURL: String
     
+    // TODO: IOS-2797 - Add link to API documentation showing possible enum values for this property.
     /// Defines the type of additional monthly parking application required. Value is `nil` if no separate application is required.
     public let separateApplicationType: String?
     


### PR DESCRIPTION
**Description**
Just looking to make this more flexible instead of restrictive. We don't use these values as enum types on our end at all, and doing this will allow the display format to be flexible and for `hours_type` to eventually included new types without impact on this SDK.