### PR TITLE
Feature/Avoid turning on debug logging when previously disabled

### DIFF
--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -16,10 +16,6 @@ class NetworkClient {
     
     init(baseURL: URLConvertible) {
         self.baseURL = baseURL
-        
-        #if DEBUG
-            self.httpClient.isDebugLoggingEnabled = true
-        #endif
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint and decodes it.


### PR DESCRIPTION
**Description**
Removes logic to enable debug logging when the `DEBUG` macro is found.

- Since the HTTP client is a shared instance, debug logging can be controlled by calling `HTTPClient.shared.isDebugLoggingEnabled = true`.
- Also due to the HTTP client being a shared instance, if a client is using `UtilityBeltNetworking` in another location besides `SpotHeroSDK` and has debug logging turned off, as soon as `NetworkClient` gets instantiated it turns it back on, overriding the client's previous choice to disable it.