### PR TITLE
IOS-2473: Feature/Add `reservationExtensionEnabled` property to `CommonFacilityAttributes`

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
@@ -14,6 +14,7 @@ public struct CommonFacilityAttributes: Codable {
         case navigationTip = "navigation_tip"
         case parkingTypes = "parking_types"
         case rating
+        case reservationExtensionEnabled = "reservation_extension_enabled"
         case restrictions
         case requirements
         case slug
@@ -56,6 +57,9 @@ public struct CommonFacilityAttributes: Codable {
     
     /// Description of the average customer rating of a facility on a scale of 0 to 5.
     public let rating: FacilityRating
+    
+    /// Whether a reservation at this facility is able to be extended after initial purchase.
+    public let reservationExtensionEnabled: Bool
     
     /// Restrictions to parking at the facility. This field may contain HTML content.
     public let restrictions: [String]


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2473

**Description**
Adds a property onto `CommonFacilityAttributes` that will be used to determine if a facility allows reservations to be extended after purchase.
