### PR TITLE
IOS-3415: Feature/Allow HTTPClient injection

### DIFF
--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -10,12 +10,17 @@ class NetworkClient {
     // MARK: Properties
     
     private let baseURL: URLConvertible
-    private let httpClient: HTTPClient = .shared
+    private let httpClient: HTTPClient
     
     // MARK: Methods
     
-    init(baseURL: URLConvertible) {
+    /// Creates a new instance of `NetworkClient`.
+    /// - Parameters:
+    ///   - baseURL: The base URL for all API requests.
+    ///   - httpClient: An `HTTPClient` through which requests will be routed. Defaults to `.shared`.
+    init(baseURL: URLConvertible, httpClient: HTTPClient = .shared) {
         self.baseURL = baseURL
+        self.httpClient = httpClient
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint and decodes it.

--- a/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
@@ -13,8 +13,11 @@ public final class SpotHeroAPIClient {
     // MARK: Methods
     
     /// Creates a new instance of `SpotHeroAPIClient`.
-    public init(baseURL: String) {
-        let networkClient = NetworkClient(baseURL: baseURL)
+    /// - Parameters:
+    ///   - baseURL: The base URL for all API requests.
+    ///   - httpClient: An `HTTPClient` through which requests will be routed. Defaults to `.shared`.
+    public init(baseURL: String, httpClient: HTTPClient = .shared) {
+        let networkClient = NetworkClient(baseURL: baseURL, httpClient: httpClient)
         
         /// V2 Endpoints
         self.search = SearchEndpoint(client: networkClient)

--- a/SpotHeroSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SpotHeroSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/spothero/UtilityBelt-iOS",
         "state": {
           "branch": null,
-          "revision": "152155de60823018913b382df038b6eca8d0e437",
-          "version": "0.10.1"
+          "revision": "be66f4a0d97c4f7b674071978e846f9b841337d4",
+          "version": "0.13.0"
         }
       }
     ]


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3415

**Description**
- Allow for an `HTTPClient` to be injected when setting up networking clients, which will enable capabilities such as mocking network requests 
- Updated UtilityBelt