### PR TITLE
IOS-3482: Feature/Add event fee support

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Enums/FacilityFee.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Enums/FacilityFee.swift
@@ -17,4 +17,6 @@ public enum FacilityFee: String, Codable {
     case oversizeFee = "oversize_fee"
     /// A fee applied to all reservations at a given facility.
     case facilityFee = "facility_fee"
+    /// A fee applied to reservations tied to events.
+    case eventFee = "event_fee"
 }

--- a/Sources/SpotHeroAPI/Search/Common/Enums/FacilityFee.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Enums/FacilityFee.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Defines the supported fee types at the facility.
 /// The difference between a fee and a tax is when they are applied:

--- a/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Represents common facility information applicable in all contexts.
 public struct CommonFacilityAttributes: Codable {

--- a/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
@@ -67,8 +67,9 @@ public struct CommonFacilityAttributes: Codable {
     /// End-user requirements for reserving a spot at the given facility.
     public let requirements: FacilityRequirements
     
-    /// An array defining the supported fee types at the facility.
-    public let supportedFeeTypes: [FacilityFee]
+    /// An array defining the fee types at the facility.
+    /// See `FacilityFee.swift` for a list of supported types.
+    public let supportedFeeTypes: [String]
     
     /// Contains all fields relevant to a facility’s cancellation policy.
     public let cancellation: Cancellation


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3482

**Description**
- Adds the new `event_fee` type to `FacilityFee`
- Updates `CommonFacilityAttributes` to use an array of strings rather than an array of finite enum values. This avoids potentially parsing issues if the API introduces new fee types in the future.