### PR TITLE
IOS-3491: Feature/Future-proof enums

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportRate.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportRate.swift
@@ -18,7 +18,8 @@ public struct AirportRate: Codable {
     public let lowestDailyRate: Currency
     
     /// Defines the garage's reservation redemption type.
-    public let redemptionType: RedemptionType
+    /// See `RedemptionType.swift` for a list of supported types.
+    public let redemptionType: String
     
     /// Metadata used for highlighting spots when showcasing recommended results.
     /// (eg. "Most Popular", "Highest Rated", etc.)

--- a/Sources/SpotHeroAPI/Search/Common/Models/Address.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/Address.swift
@@ -45,5 +45,6 @@ public struct Address: Codable {
     public let timeZone: String
     
     /// An array of types defining the purpose of the address/entrance at the facility.
-    public let types: [AddressType]
+    /// See `AddressType.swift` for a list of supported types.
+    public let types: [String]
 }

--- a/Sources/SpotHeroAPI/Search/Common/Models/Amenity.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/Amenity.swift
@@ -15,5 +15,6 @@ public struct Amenity: Codable {
     public let displayName: String
     
     /// A value which uniquely distinguishes a type of amenity at a parking spot.
-    public let type: AmenityType
+    /// See `AmenityType.swift` for a list of supported types.
+    public let type: String
 }

--- a/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/CommonFacilityAttributes.swift
@@ -38,7 +38,8 @@ public struct CommonFacilityAttributes: Codable {
     public let description: String
     
     /// The facility type designation.
-    public let facilityType: FacilityType
+    /// See `FacilityType.swift` for a list of supported types.
+    public let facilityType: String
     
     /// Custom instructions for end-user to aid in locating facility. This field may contain HTML content.
     public let navigationTip: String
@@ -53,7 +54,8 @@ public struct CommonFacilityAttributes: Codable {
     public let images: [ImageInfo]
     
     /// Parking types offered at this facility.
-    public let parkingTypes: [FacilityParkingType]
+    /// See `FacilityParkingType.swift` for a list of supported types.
+    public let parkingTypes: [String]
     
     /// Description of the average customer rating of a facility on a scale of 0 to 5.
     public let rating: FacilityRating

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyRate.swift
@@ -32,7 +32,8 @@ public struct MonthlyRate: Codable {
     public let redemptionInstructions: MonthlyRedemptionInstructions
     
     /// Defines the garage's reservation redemption type.
-    public let redemptionType: RedemptionType
+    /// See `RedemptionType.swift` for a list of supported types. 
+    public let redemptionType: String
     
     /// The type of parking pass supported at a parking spot.
     public let parkingPass: ParkingPass

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
@@ -16,5 +16,6 @@ public struct TransientRate: Codable {
     public let earlyBird: EarlyBird?
     
     /// Defines the garage's reservation redemption type.
-    public let redemptionType: RedemptionType
+    /// See `RedemptionType.swift` for a list of supported types. 
+    public let redemptionType: String
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3491

**Description**
Updates deserialization to use strings instead of enumeration values. Enumeration conversion will happen in the app.