### PR TITLE
IOS-3457: Ensure spots are available when using the searchTransientFacilityParking endpoint

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
@@ -2,6 +2,9 @@
 
 /// Represents an availability search result containing airport facility and rate information.
 public struct AirportFacilityResult: Codable {
+    /// Availability of a given parking facility.
+    public let availability: Availability
+    
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?
     

--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
@@ -3,7 +3,7 @@
 /// Represents an availability search result containing airport facility and rate information.
 public struct AirportFacilityResult: Codable {
     /// Availability of a given parking facility.
-    public let availability: Availability
+    public let availability: Availability?
     
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?

--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
@@ -3,6 +3,7 @@
 /// Represents an availability search result containing airport facility and rate information.
 public struct AirportFacilityResult: Codable {
     /// Availability of a given parking facility.
+    /// 
     public let availability: Availability?
     
     /// Distance calculations between the facility and the search origin.

--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacilityResult.swift
@@ -3,7 +3,6 @@
 /// Represents an availability search result containing airport facility and rate information.
 public struct AirportFacilityResult: Codable {
     /// Availability of a given parking facility.
-    /// 
     public let availability: Availability?
     
     /// Distance calculations between the facility and the search origin.

--- a/Sources/SpotHeroAPI/Search/Common/Models/Availability.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/Availability.swift
@@ -1,0 +1,7 @@
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public struct Availability: Codable {
+    public let available: Bool?
+}

--- a/Sources/SpotHeroAPI/Search/Common/Models/Availability.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/Availability.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+/// A model representing availability of a given parking facility.
 public struct Availability: Codable {
+    /// The boolean that informs us whether the spot is available
     public let available: Bool?
 }

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacilityResult.swift
@@ -2,6 +2,9 @@
 
 /// Represents an availability search result containing monthly facility and rate information.
 public struct MonthlyFacilityResult: Codable {
+    /// Availability of a given parking facility.
+    public let availability: Availability
+    
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?
     

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacilityResult.swift
@@ -3,7 +3,7 @@
 /// Represents an availability search result containing monthly facility and rate information.
 public struct MonthlyFacilityResult: Codable {
     /// Availability of a given parking facility.
-    public let availability: Availability
+    public let availability: Availability?
     
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
@@ -2,6 +2,9 @@
 
 /// Represents an availability search result containing transient facility and rate information.
 public struct TransientFacilityResult: Codable {
+    /// Whether the spot is available,
+    ///  ADD BETTER DESCRIPTION
+    public let availability: Availability
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?
     

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
@@ -3,7 +3,7 @@
 /// Represents an availability search result containing transient facility and rate information.
 public struct TransientFacilityResult: Codable {
     /// Availability of a given parking facility.
-    public let availability: Availability
+    public let availability: Availability?
     
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
@@ -2,9 +2,9 @@
 
 /// Represents an availability search result containing transient facility and rate information.
 public struct TransientFacilityResult: Codable {
-    /// Whether the spot is available,
-    ///  ADD BETTER DESCRIPTION
+    /// Availability of a given parking facility.
     public let availability: Availability
+    
     /// Distance calculations between the facility and the search origin.
     public let distance: Distance?
     


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3457

**Description**
Updated SpotHeroSDK to begin parsing availability information when performing searches
