### PR TITLE
IOS-3513: Bugfix/Use a double value for the max distance

### DIFF
--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -81,7 +81,7 @@ public extension SearchGetMonthlyFacilitiesRequest {
         
         /// Maximum distance in meters from the origin from which facility results will be generated.
         /// The default is 804.672 meters (.5 miles). The value is capped at 8046.72 meters (5 miles).
-        private let maxDistanceMeters: Int?
+        private let maxDistanceMeters: Double?
         
         /// The number of results to include in a single page.
         /// The default is nil (no limit). Must be >= 1, if provided.
@@ -99,7 +99,7 @@ public extension SearchGetMonthlyFacilitiesRequest {
                     workLatitude: Double? = nil,
                     workLongitude: Double? = nil,
                     startDate: Date? = nil,
-                    maxDistanceMeters: Int? = nil,
+                    maxDistanceMeters: Double? = nil,
                     pageSize: Int? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude

--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilitiesRequest.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UtilityBeltNetworking

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -93,7 +93,7 @@ public extension SearchGetTransientFacilitiesRequest {
         
         /// Maximum distance in meters from the origin from which facility results will be generated.
         /// The default is 804.672 meters (.5 miles). The value is capped at 8046.72 meters (5 miles).
-        private let maxDistanceMeters: Int?
+        private let maxDistanceMeters: Double?
         
         /// The number of results to include in a single page.
         /// The default is nil (no limit). Must be >= 1, if provided.
@@ -113,7 +113,7 @@ public extension SearchGetTransientFacilitiesRequest {
                     startDate: Date? = nil,
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
-                    maxDistanceMeters: Int? = nil,
+                    maxDistanceMeters: Double? = nil,
                     pageSize: Int? = nil,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.latitude = latitude

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UtilityBeltNetworking


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3513

**Description**
The expected value is a double for `max_distance_meters`. Updates from Int to a Double.
