### PR TITLE
IOS-3538: (Part 5) Feature/Creates a common facility protocol

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacility.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Representation of an airport facility.
 public struct AirportFacility: CommonFacility {

--- a/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Models/AirportFacility.swift
@@ -1,7 +1,7 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 /// Representation of an airport facility.
-public struct AirportFacility: Codable {
+public struct AirportFacility: CommonFacility {
     /// Represents common facility information applicable in all contexts.
     public let common: CommonFacilityAttributes
     

--- a/Sources/SpotHeroAPI/Search/Common/Protocols/CommonFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Protocols/CommonFacility.swift
@@ -1,0 +1,7 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+/// Representation of a facility.
+public protocol CommonFacility: Codable {
+    /// Represents common facility information applicable in all contexts.
+    var common: CommonFacilityAttributes { get }
+}

--- a/Sources/SpotHeroAPI/Search/Common/Protocols/CommonFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Protocols/CommonFacility.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Representation of a facility.
 public protocol CommonFacility: Codable {

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacility.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Representation of a monthly facility.
 public struct MonthlyFacility: CommonFacility {

--- a/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Models/MonthlyFacility.swift
@@ -1,7 +1,7 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 /// Representation of a monthly facility.
-public struct MonthlyFacility: Codable {
+public struct MonthlyFacility: CommonFacility {
     /// Represents common facility information applicable in all contexts.
     public let common: CommonFacilityAttributes
     

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacility.swift
@@ -1,7 +1,7 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 /// Representation of a transient facility.
-public struct TransientFacility: Codable {
+public struct TransientFacility: CommonFacility {
     /// Represents common facility information applicable in all contexts.
     public let common: CommonFacilityAttributes
     

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacility.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacility.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 /// Representation of a transient facility.
 public struct TransientFacility: CommonFacility {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3538

**Description**
Creates a common facility protocol that can be used to reference facilities generally in SpotHero-iOS.

This is needed for the updates in https://github.com/spothero/SpotHero-iOS/pull/5874
