### PR TITLE
IOS-3533: Updated user agent in network' request header

### DIFF
--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -43,17 +43,11 @@ class NetworkClient {
                                        encoding: ParameterEncoding? = nil,
                                        decoder: JSONDecoder = .spotHeroAPI,
                                        completion: RequestCompletion<T>? = nil) -> Request? {
-        var updatedHeaders = self.headers?.asHeaderDictionary()
-        if let headersDict = headers?.asHeaderDictionary() {
-            // If we have existing headers that were passed in as a function parameter, then merge it with self.headers passed during class init
-            // If the are conflicting values for the same key then we will use the value from the function parameter
-            updatedHeaders?.merge(headersDict) { _, new in new }
-        }
         return self.httpClient.request(
             url,
             method: method,
             parameters: parameters,
-            headers: updatedHeaders,
+            headers: updatedHeaders(headers: headers),
             encoding: encoding,
             decoder: decoder
         ) { (response: DataResponse<T, Error>) in
@@ -134,5 +128,22 @@ extension NetworkClient {
                             encoding: encoding,
                             decoder: decoder,
                             completion: completion)
+    }
+}
+
+extension NetworkClient {
+    private func updatedHeaders(headers: HTTPHeaderDictionaryConvertible?) -> [String : String] {
+        var updatedHeaders: [String : String] = [:]
+        
+        if let newHeaders = self.headers?.asHeaderDictionary() {
+            updatedHeaders = newHeaders
+        }
+        
+        if let headersDict = headers?.asHeaderDictionary() {
+            // If we have existing headers that were passed in as a function parameter, then merge it with self.headers passed during class init
+            // If the are conflicting values for the same key then we will use the value from the function parameter
+            updatedHeaders.merge(headersDict) { _, new in new }
+        }
+        return updatedHeaders
     }
 }

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -134,7 +134,7 @@ extension NetworkClient {
 }
 
 extension NetworkClient {
-    private func updatedHeaders(buildNumber: Int? = nil, headers: HTTPHeaderDictionaryConvertible? = nil) -> HTTPHeaderDictionaryConvertible?  {
+    private func updatedHeaders(buildNumber: Int? = nil, headers: HTTPHeaderDictionaryConvertible? = nil) -> HTTPHeaderDictionaryConvertible? {
         if let buildNumber = self.buildNumber, headers == nil {
             return [APIHeaders.HTTPHeaderField.userAgent.rawValue: "ios-native-build-\(buildNumber)"]
         }

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -47,9 +47,9 @@ class NetworkClient {
         var updatedHeaders = self.headers?.asHeaderDictionary()
         if let headersDict = headers?.asHeaderDictionary() {
             // If we have existing headers that were passed in as a function parameter, then merge it with self.headers passed during class init
-            updatedHeaders?.merge(headersDict) { (current, _) in current } 
+            // If the are conflicting values for the same key then we will use the value from the function parameter
+            updatedHeaders?.merge(headersDict) { _, new in new }
         }
-
         return self.httpClient.request(
             url,
             method: method,

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -1,8 +1,8 @@
 // Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
-import UtilityBeltNetworking
 import SpotHeroAPI
+import UtilityBeltNetworking
 
 /// Represents the completion block for a SpotHero API request.
 public typealias RequestCompletion<T: Decodable> = (Result<T, Error>) -> Void
@@ -44,7 +44,6 @@ class NetworkClient {
                                        encoding: ParameterEncoding? = nil,
                                        decoder: JSONDecoder = .spotHeroAPI,
                                        completion: RequestCompletion<T>? = nil) -> Request? {
-        
         return self.httpClient.request(
             url,
             method: method,

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -11,7 +11,7 @@ class NetworkClient {
     
     private let baseURL: URLConvertible
     private let httpClient: HTTPClient
-    private let buildNumber: Int?
+    private let headers: HTTPHeaderDictionaryConvertible?
     
     // MARK: Methods
     
@@ -19,10 +19,10 @@ class NetworkClient {
     /// - Parameters:
     ///   - baseURL: The base URL for all API requests.
     ///   - httpClient: An `HTTPClient` through which requests will be routed. Defaults to `.shared`.
-    init(baseURL: URLConvertible, httpClient: HTTPClient = .shared, buildNumber: Int? = nil) {
+    init(baseURL: URLConvertible, httpClient: HTTPClient = .shared, headers: HTTPHeaderDictionaryConvertible? = nil) {
         self.baseURL = baseURL
         self.httpClient = httpClient
-        self.buildNumber = buildNumber
+        self.headers = headers
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
@@ -43,11 +43,12 @@ class NetworkClient {
                                        encoding: ParameterEncoding? = nil,
                                        decoder: JSONDecoder = .spotHeroAPI,
                                        completion: RequestCompletion<T>? = nil) -> Request? {
+        let updatedHeaders = headers == nil ? self.headers : headers
         return self.httpClient.request(
             url,
             method: method,
             parameters: parameters,
-            headers: updatedHeaders(buildNumber: self.buildNumber, headers: headers),
+            headers: updatedHeaders,
             encoding: encoding,
             decoder: decoder
         ) { (response: DataResponse<T, Error>) in
@@ -128,14 +129,5 @@ extension NetworkClient {
                             encoding: encoding,
                             decoder: decoder,
                             completion: completion)
-    }
-}
-
-extension NetworkClient {
-    private func updatedHeaders(buildNumber: Int? = nil, headers: HTTPHeaderDictionaryConvertible? = nil) -> HTTPHeaderDictionaryConvertible? {
-        if let buildNumber = self.buildNumber, headers == nil {
-            return ["User-Agent": "ios-native-build-\(buildNumber)"]
-        }
-        return nil
     }
 }

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -43,7 +43,6 @@ class NetworkClient {
                                        encoding: ParameterEncoding? = nil,
                                        decoder: JSONDecoder = .spotHeroAPI,
                                        completion: RequestCompletion<T>? = nil) -> Request? {
-        
         var updatedHeaders = self.headers?.asHeaderDictionary()
         if let headersDict = headers?.asHeaderDictionary() {
             // If we have existing headers that were passed in as a function parameter, then merge it with self.headers passed during class init

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -43,7 +43,13 @@ class NetworkClient {
                                        encoding: ParameterEncoding? = nil,
                                        decoder: JSONDecoder = .spotHeroAPI,
                                        completion: RequestCompletion<T>? = nil) -> Request? {
-        let updatedHeaders = headers == nil ? self.headers : headers
+        
+        var updatedHeaders = self.headers?.asHeaderDictionary()
+        if let headersDict = headers?.asHeaderDictionary() {
+            // If we have existing headers that were passed in as a function parameter, then merge it with self.headers passed during class init
+            updatedHeaders?.merge(headersDict) { (current, _) in current } 
+        }
+
         return self.httpClient.request(
             url,
             method: method,

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -132,8 +132,8 @@ extension NetworkClient {
 }
 
 extension NetworkClient {
-    private func updatedHeaders(headers: HTTPHeaderDictionaryConvertible?) -> [String : String] {
-        var updatedHeaders: [String : String] = [:]
+    private func updatedHeaders(headers: HTTPHeaderDictionaryConvertible?) -> [String: String] {
+        var updatedHeaders: [String: String] = [:]
         
         if let newHeaders = self.headers?.asHeaderDictionary() {
             updatedHeaders = newHeaders

--- a/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/NetworkClient.swift
@@ -1,7 +1,6 @@
 // Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
-import SpotHeroAPI
 import UtilityBeltNetworking
 
 /// Represents the completion block for a SpotHero API request.
@@ -135,7 +134,7 @@ extension NetworkClient {
 extension NetworkClient {
     private func updatedHeaders(buildNumber: Int? = nil, headers: HTTPHeaderDictionaryConvertible? = nil) -> HTTPHeaderDictionaryConvertible? {
         if let buildNumber = self.buildNumber, headers == nil {
-            return [APIHeaders.HTTPHeaderField.userAgent.rawValue: "ios-native-build-\(buildNumber)"]
+            return ["User-Agent": "ios-native-build-\(buildNumber)"]
         }
         return nil
     }

--- a/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
@@ -16,10 +16,10 @@ public final class SpotHeroAPIClient {
     /// - Parameters:
     ///   - baseURL: The base URL for all API requests.
     ///   - httpClient: An `HTTPClient` through which requests will be routed. Defaults to `.shared`.
-    public init(baseURL: String, httpClient: HTTPClient = .shared, buildNumber: Int? = nil) {
+    public init(baseURL: String, httpClient: HTTPClient = .shared, headers: HTTPHeaderDictionaryConvertible? = nil) {
         let networkClient = NetworkClient(baseURL: baseURL,
                                           httpClient: httpClient,
-                                          buildNumber: buildNumber)
+                                          headers: headers)
         
         /// V2 Endpoints
         self.search = SearchEndpoint(client: networkClient)

--- a/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
+++ b/Sources/SpotHeroAPI/Core/Helpers/SpotHeroAPIClient.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UtilityBeltNetworking
@@ -16,8 +16,10 @@ public final class SpotHeroAPIClient {
     /// - Parameters:
     ///   - baseURL: The base URL for all API requests.
     ///   - httpClient: An `HTTPClient` through which requests will be routed. Defaults to `.shared`.
-    public init(baseURL: String, httpClient: HTTPClient = .shared) {
-        let networkClient = NetworkClient(baseURL: baseURL, httpClient: httpClient)
+    public init(baseURL: String, httpClient: HTTPClient = .shared, buildNumber: Int? = nil) {
+        let networkClient = NetworkClient(baseURL: baseURL,
+                                          httpClient: httpClient,
+                                          buildNumber: buildNumber)
         
         /// V2 Endpoints
         self.search = SearchEndpoint(client: networkClient)


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3533?atlOrigin=eyJpIjoiZGI3NzNkYTgyYjAzNGU4MTllOWM4MTM4MGFhNmE3MDIiLCJwIjoiaiJ9

**Description**
The issue is that when making a network request we do not assign `User-Agent` property to a request's header. This causes issue like the one reported in the ticket where we display unavailable spots that were turned off to mobile by BE
