### PR TITLE
IOS-3897: Added originLatitude and originLongitude for distance calculations

### DIFF
--- a/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Monthly/Requests/SearchGetMonthlyFacilityRequest.swift
@@ -38,6 +38,8 @@ public extension SearchGetMonthlyFacilityRequest {
     struct Parameters: Encodable, SearchTracking, ParameterDictionaryConvertible {
         private enum CodingKeys: String, CodingKey {
             case startDate = "starts"
+            case originLatitude = "origin_lat"
+            case originLongitude = "origin_lon"
             case workLatitude = "work_lat"
             case workLongitude = "work_lon"
             case includeWalkingDistance = "include_walking_distance"
@@ -51,6 +53,16 @@ public extension SearchGetMonthlyFacilityRequest {
         /// Start date from which results will be generated. The supported format is YYYY-MM-DD.
         /// If this parameter is not provided, results will be generated from the date at which the request was received.
         private let startDate: Date?
+
+        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLongitude` parameter, if applicable. Origin latitude must be in [-90, 90].
+        private let originLatitude: Double?
+
+        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLatitude` parameter, if applicable. Origin longitude must be in [-180, 180].
+        private let originLongitude: Double?
         
         /// The work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
         private let workLatitude: Double?
@@ -67,11 +79,15 @@ public extension SearchGetMonthlyFacilityRequest {
         let sessionID: String?
         
         public init(startDate: Date? = nil,
+                    originLatitude: Double? = nil,
+                    originLongitude: Double? = nil,
                     workLatitude: Double? = nil,
                     workLongitude: Double? = nil,
                     includeWalkingDistance: Bool = true,
                     searchTracking: SearchTrackingParameters? = nil) {
             self.startDate = startDate
+            self.originLatitude = originLatitude
+            self.originLongitude = originLongitude
             self.workLatitude = workLatitude
             self.workLongitude = workLongitude
             self.includeWalkingDistance = includeWalkingDistance

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -40,6 +40,8 @@ public extension SearchGetTransientFacilityRequest {
             case endDate = "ends"
             case isOversize = "oversize"
             case startDate = "starts"
+            case originLatitude = "origin_lat"
+            case originLongitude = "origin_lon"
             case workLatitude = "work_lat"
             case workLongitude = "work_lon"
             
@@ -64,6 +66,16 @@ public extension SearchGetTransientFacilityRequest {
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
         private let isOversize: Bool?
+
+        /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLongitude` parameter, if applicable. Origin latitude must be in [-90, 90].
+        private let originLatitude: Double?
+
+        /// Longitude in decimal degrees of origin from where each result's distance will be calculated.
+        /// Intended use case is to accurately calculate result distances from the initial search location after panning to a new area on the map.
+        /// Must be specified with `originLatitude` parameter, if applicable. Origin longitude must be in [-180, 180].
+        private let originLongitude: Double?
         
         /// The work address latitude associated with the user’s commuter benefits card. Latitude must be in [-90, 90].
         private let workLatitude: Double?
@@ -82,6 +94,8 @@ public extension SearchGetTransientFacilityRequest {
         public init(startDate: Date? = nil,
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
+                    originLatitude: Double? = nil,
+                    originLongitude: Double? = nil,
                     workLatitude: Double? = nil,
                     workLongitude: Double? = nil,
                     searchTracking: SearchTrackingParameters? = nil,
@@ -89,6 +103,8 @@ public extension SearchGetTransientFacilityRequest {
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
+            self.originLatitude = originLatitude
+            self.originLongitude = originLongitude
             self.workLatitude = workLatitude
             self.workLongitude = workLongitude
             


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3897

**Description**
Follow up on #97: we need to pass in the `originLatitude` and `originLongitude` to get the distance information.
