### PR TITLE
SEAR-2372 add github action hook repository_dispatch to trigger testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  repository_dispatch:
 
 env:
   PACKAGE_NAME: SpotHeroSDK


### PR DESCRIPTION
https://spothero.atlassian.net/browse/SEAR-2372

Adds repository_dispatch event to be able to trigger testing remotely.

This has proven working in the canary, see https://github.com/spothero/canary/blob/main/.github/workflows/manual.yml

Context: https://spothero.slack.com/archives/CBB351AV9/p1674494343004789
