### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
+        device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (3rd generation)"]
         os: ["16.2"]
         xcode_version: ["14.2.0"]
     steps:
@@ -78,8 +78,8 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        device_name: ["Apple TV 4K"]
-        os: ["16.2"]
+        device_name: ["Apple TV 4K (3rd generation)"]
+        os: ["16.1"]
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
         os: ["16.0"]
-        xcode_version: latest-stable
+        xcode_version: [latest-stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        xcode_version: latest-stable
+        xcode_version: [latest-stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
       matrix:
         device_name: ["Apple TV 4K"]
         os: ["16.0"]
-        xcode_version: latest-stable
+        xcode_version: [latest-stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-12]
-        xcode_version: latest-stable
+        xcode_version: [latest-stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
           bundle install
@@ -43,7 +43,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -62,7 +62,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -83,7 +83,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -103,7 +103,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5
       - name: Install Dependencies
         run: |
           bundle install
@@ -43,7 +43,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -62,7 +62,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -83,7 +83,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -103,7 +103,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
         os: ["16.0"]
-        xcode_version:latest-stable
+        xcode_version: latest-stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
-        os: ["16.0"]
-        xcode_version: [latest-stable]
+        os: ["16.2"]
+        xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        xcode_version: [latest-stable]
+        xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -79,8 +79,8 @@ jobs:
     strategy:
       matrix:
         device_name: ["Apple TV 4K"]
-        os: ["16.0"]
-        xcode_version: [latest-stable]
+        os: ["16.2"]
+        xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-12]
-        xcode_version: [latest-stable]
+        xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: macos-11
+    runs-on: macos-12
     permissions: 
       pull-requests: write
     env:
@@ -34,13 +34,13 @@ jobs:
         run: sh ./scripts/danger_lint.sh
   iOS:
     name: iOS ${{ matrix.os }} ${{ matrix.device_name }}
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [lint]
     strategy:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
-        os: ["15.0"]
-        xcode_version: ["13.0"]
+        os: ["16.0"]
+        xcode_version:latest-stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -55,11 +55,11 @@ jobs:
           path: ${{ env.DEPLOY_DIRECTORY }}
   macOS:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [lint]
     strategy:
       matrix:
-        xcode_version: ["13.0"]
+        xcode_version: latest-stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -70,17 +70,17 @@ jobs:
       - name: Upload Step Output
         uses: actions/upload-artifact@v1
         with:
-          name: "macOS 10.15 Output"
+          name: "macOS 12 Output"
           path: ${{ env.DEPLOY_DIRECTORY }}
   tvOS:
     name: tvOS ${{ matrix.os }} ${{ matrix.device_name }}
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [lint]
     strategy:
       matrix:
         device_name: ["Apple TV 4K"]
-        os: ["15.0"]
-        xcode_version: ["13.0"]
+        os: ["16.0"]
+        xcode_version: latest-stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -99,8 +99,8 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        os: [macos-11]
-        xcode_version: ["13.0"]
+        os: [macos-12]
+        xcode_version: latest-stable
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5
+        uses: actions/checkout@v3.5.0
       - name: Install Dependencies
         run: |
           bundle install
@@ -43,7 +43,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5
+        uses: actions/checkout@v3.5.0
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -62,7 +62,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5
+        uses: actions/checkout@v3.5.0
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -83,7 +83,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5
+        uses: actions/checkout@v3.5.0
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
@@ -103,7 +103,7 @@ jobs:
         xcode_version: ["14.2.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5
+        uses: actions/checkout@v3.5.0
       - name: Switch Xcode Version
         run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
-// swift-tools-version:5.3
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// swift-tools-version:5.6
+// Copyright © 2023 SpotHero, Inc. All rights reserved.
 
 import PackageDescription
 
@@ -13,26 +13,23 @@ let package = Package(
     ],
     products: [
         .library(name: "SpotHeroAPINext", targets: ["SpotHeroAPINext"]),
-        // Dynamic Libraries
-        // These libraries are required due to the Xcode 11.3+ static linking bug: https://bugs.swift.org/browse/SR-12303
-        .library(name: "SpotHeroAPINextDynamic", type: .dynamic, targets: ["SpotHeroAPINext"]),
     ],
     dependencies: [
-        .package(name: "UtilityBelt", url: "https://github.com/spothero/UtilityBelt-iOS", .upToNextMinor(from: "0.14.0")),
+        .package(url: "https://github.com/spothero/UtilityBelt-iOS", .upToNextMinor(from: "0.14.0")),
     ],
     targets: [
         .target(
             name: "SpotHeroAPINext",
             dependencies: [
-                .product(name: "UtilityBeltNetworking", package: "UtilityBelt"),
+                .product(name: "UtilityBeltNetworking", package: "UtilityBelt-iOS"),
             ],
             path: "Sources/SpotHeroAPI"
         ),
         .testTarget(
             name: "SpotHeroAPITests",
             dependencies: [
-                .product(name: "Sham", package: "UtilityBelt"),
-                .product(name: "Sham_XCTestSupport", package: "UtilityBelt"),
+                .product(name: "Sham", package: "UtilityBelt-iOS"),
+                .product(name: "Sham_XCTestSupport", package: "UtilityBelt-iOS"),
                 .target(name: "SpotHeroAPINext"),
             ],
             resources: [.process("Resources")]


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
Update GitHub Actions to a more modern OS and Xcode version.
Updates SPM version.
Addresses an outdated GitHub Action that was causing warnings, checkout updated to v3.5.0.

This came about from a discussion that there were failing actions occurring. https://spothero.slack.com/archives/C010V0UQRC4/p1680721297556799
