### PR TITLE
Update TransientRateExtensionResponse.swift

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientRateExtensionResponse.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientRateExtensionResponse.swift
@@ -3,5 +3,5 @@
 /// The response returned when fetching extension rates for transient facility.
 public struct TransientRateExtensionResponse: Codable {
     /// The fetched extension rate result.
-    public let result: [ExtensionQuoteContainer]
+    public let results: [ExtensionQuoteContainer]
 }


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
BE decided to change the endpoint response from 
```
"result" : {
...
}
```
to
```
"results" : {
...
}
```
