### PR TITLE
Make rate_type optional

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
@@ -26,5 +26,5 @@ public struct TransientRate: Codable {
     public let ruleGroupTitle: String
 
     /// The type of the rate.
-    public let rateType: String
+    public let rateType: String?
 }


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
Misunderstanding with BE team. Turned out rate_type should be an optional
