### PR TITLE
IOS-4640: Added cancellationThresholdInMinutes

### DIFF
--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientRate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2023 SpotHero, Inc. All rights reserved.
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
 
 /// Transient-specific metadata pertaining to a rate for the rental of a parking spot.
 public struct TransientRate: Codable {
@@ -8,8 +8,9 @@ public struct TransientRate: Codable {
         case redemptionType = "redemption_type"
         case ruleGroupTitle = "rule_group_title"
         case rateType = "rate_type"
+        case cancellationThresholdInMinutes = "cancellation_threshold_minutes"
     }
-    
+
     /// Transient parking amenities offered at the facility.
     public let amenities: [Amenity]
     
@@ -27,4 +28,17 @@ public struct TransientRate: Codable {
 
     /// The type of the rate.
     public let rateType: String?
+    
+    /// The number of minutes before an event starts which the user has to cancel the reservation.
+    public let cancellationThresholdInMinutes: Int
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.amenities = try container.decode([Amenity].self, forKey: .amenities)
+        self.earlyBird = try container.decodeIfPresent(TransientRate.EarlyBird.self, forKey: .earlyBird)
+        self.redemptionType = try container.decode(String.self, forKey: .redemptionType)
+        self.ruleGroupTitle = try container.decode(String.self, forKey: .ruleGroupTitle)
+        self.rateType = try container.decodeIfPresent(String.self, forKey: .rateType)
+        self.cancellationThresholdInMinutes = (try? container.decodeIfPresent(Int.self, forKey: .cancellationThresholdInMinutes)) ?? 0
+    }
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-4640

**Description**
This is currently only available on sandbox so I overrode the synthesized `init(from:)` to default to 0 -- I didn't want to make it optional because when it is deployed to production, it won't be.
