### PR TITLE
iOS-4758: `vehicle_info_id` in search

### DIFF
--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilitiesRequest.swift
@@ -45,6 +45,8 @@ public extension SearchGetAirportFacilitiesRequest {
             case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
+            
+            case vehicleInfoId = "vehicle_info_id"
         }
         
         /// IATA airport code used as the origin position.
@@ -68,6 +70,9 @@ public extension SearchGetAirportFacilitiesRequest {
         /// The default is nil (no limit). Must be >= 1, if provided.
         private let pageSize: Int?
         
+        /// An optional vehicle info id.
+        private let vehicleInfoId: Int?
+        
         let actionID: String?
         let fingerprint: String?
         let searchID: String?
@@ -78,12 +83,14 @@ public extension SearchGetAirportFacilitiesRequest {
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
                     pageSize: Int? = nil,
-                    searchTracking: SearchTrackingParameters? = nil) {
+                    searchTracking: SearchTrackingParameters? = nil,
+                    vehicleInfoId: Int? = nil) {
             self.iataCode = iataCode
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
             self.pageSize = pageSize
+            self.vehicleInfoId = vehicleInfoId
             
             self.actionID = searchTracking?.actionID
             self.fingerprint = searchTracking?.fingerprint

--- a/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Airport/Requests/SearchGetAirportFacilityRequest.swift
@@ -45,6 +45,8 @@ public extension SearchGetAirportFacilityRequest {
             case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
+            
+            case vehicleInfoId = "vehicle_info_id"
         }
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
@@ -61,6 +63,9 @@ public extension SearchGetAirportFacilityRequest {
         /// will incorporate pricing for an oversize vehicle, if applicable.
         private let isOversize: Bool?
         
+        /// An optional vehicle info id.
+        private let vehicleInfoId: Int?
+        
         let actionID: String?
         let fingerprint: String?
         let searchID: String?
@@ -69,10 +74,12 @@ public extension SearchGetAirportFacilityRequest {
         public init(startDate: Date? = nil,
                     endDate: Date? = nil,
                     isOversize: Bool? = nil,
-                    searchTracking: SearchTrackingParameters? = nil) {
+                    searchTracking: SearchTrackingParameters? = nil,
+                    vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
+            self.vehicleInfoId = vehicleInfoId
             
             self.actionID = searchTracking?.actionID
             self.fingerprint = searchTracking?.fingerprint

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
@@ -112,6 +112,7 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 case periods
                 case includeWalkingDistance = "include_walking_distance"
                 case sortBy = "sort_by"
+                case vehicleInfoId = "vehicle_info_id"
             }
 
             // swiftlint:enable nesting
@@ -136,6 +137,9 @@ public extension BulkSearchGetTransientFacilitiesRequest {
             /// The number of results to include in a single page.
             /// The default is nil (no limit). Must be >= 1, if provided.
             let pageSize: Int?
+            
+            /// An optional vehicle info id.
+            let vehicleInfoId: Int?
         }
 
         fileprivate let queryParameters: QueryParameters
@@ -170,7 +174,8 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                     sortBy: SortByType? = .relevance,
                     inFacilityExclusionExperiment: Bool? = nil,
                     pageSize: Int? = nil,
-                    searchTracking: SearchTrackingParameters? = nil) {
+                    searchTracking: SearchTrackingParameters? = nil,
+                    vehicleInfoId: Int? = nil) {
             self.queryParameters = .init(
                 latitude: latitude,
                 longitude: longitude,
@@ -190,7 +195,8 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 maxDistanceMeters: maxDistanceMeters,
                 includeWalkingDistance: includeWalkingDistance,
                 sortBy: sortBy,
-                pageSize: pageSize
+                pageSize: pageSize,
+                vehicleInfoId: vehicleInfoId
             )
         }
     }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
@@ -66,6 +66,7 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 case fingerprint
                 case searchID = "search_id"
                 case sessionID = "session_id"
+                case vehicleInfoId = "vehicle_info_id"
             }
 
             // swiftlint:enable nesting
@@ -96,6 +97,9 @@ public extension BulkSearchGetTransientFacilitiesRequest {
 
             /// A boolean value indicating whether or not the client is included in the facility exclusion experiment.
             let inFacilityExclusionExperiment: Bool?
+            
+            /// An optional vehicle info id.
+            let vehicleInfoId: Int?
 
             let actionID: String?
             let fingerprint: String?
@@ -112,7 +116,6 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 case periods
                 case includeWalkingDistance = "include_walking_distance"
                 case sortBy = "sort_by"
-                case vehicleInfoId = "vehicle_info_id"
             }
 
             // swiftlint:enable nesting
@@ -137,9 +140,6 @@ public extension BulkSearchGetTransientFacilitiesRequest {
             /// The number of results to include in a single page.
             /// The default is nil (no limit). Must be >= 1, if provided.
             let pageSize: Int?
-            
-            /// An optional vehicle info id.
-            let vehicleInfoId: Int?
         }
 
         fileprivate let queryParameters: QueryParameters
@@ -183,7 +183,8 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 originLongitude: originLongitude,
                 workLatitude: workLatitude,
                 workLongitude: workLongitude,
-                inFacilityExclusionExperiment: inFacilityExclusionExperiment,
+                inFacilityExclusionExperiment: inFacilityExclusionExperiment, 
+                vehicleInfoId: vehicleInfoId,
                 actionID: searchTracking?.actionID,
                 fingerprint: searchTracking?.fingerprint,
                 searchID: searchTracking?.searchID,
@@ -195,8 +196,7 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 maxDistanceMeters: maxDistanceMeters,
                 includeWalkingDistance: includeWalkingDistance,
                 sortBy: sortBy,
-                pageSize: pageSize,
-                vehicleInfoId: vehicleInfoId
+                pageSize: pageSize
             )
         }
     }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilitiesRequest.swift
@@ -183,7 +183,7 @@ public extension BulkSearchGetTransientFacilitiesRequest {
                 originLongitude: originLongitude,
                 workLatitude: workLatitude,
                 workLongitude: workLongitude,
-                inFacilityExclusionExperiment: inFacilityExclusionExperiment, 
+                inFacilityExclusionExperiment: inFacilityExclusionExperiment,
                 vehicleInfoId: vehicleInfoId,
                 actionID: searchTracking?.actionID,
                 fingerprint: searchTracking?.fingerprint,

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilityRequest.swift
@@ -95,6 +95,7 @@ public extension BulkSearchGetTransientFacilityRequest {
                 case periods
                 case includeWalkingDistance = "include_walking_distance"
                 case sortBy = "sort_by"
+                case vehicleInfoId = "vehicle_info_id"
             }
 
             /// Boolean that denotes whether or not the pricing calculated for this vehicle
@@ -109,6 +110,9 @@ public extension BulkSearchGetTransientFacilityRequest {
             
             /// A string value to sort the items by.
             let sortBy: SortByType?
+            
+            /// An optional vehicle info id.
+            let vehicleInfoId: Int?
         }
 
         fileprivate let queryParameters: QueryParameters
@@ -138,7 +142,8 @@ public extension BulkSearchGetTransientFacilityRequest {
                     workLongitude: Double? = nil,
                     searchTracking: SearchTrackingParameters? = nil,
                     includeWalkingDistance: Bool = true,
-                    sortBy: SortByType? = .relevance) {
+                    sortBy: SortByType? = .relevance,
+                    vehicleInfoId: Int? = nil) {
             self.queryParameters = .init(
                 originLatitude: originLatitude,
                 originLongitude: originLongitude,
@@ -153,7 +158,8 @@ public extension BulkSearchGetTransientFacilityRequest {
                 isOversize: isOversize,
                 periods: periods,
                 includeWalkingDistance: includeWalkingDistance,
-                sortBy: sortBy
+                sortBy: sortBy,
+                vehicleInfoId: vehicleInfoId
             )
         }
     }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/BulkSearchGetTransientFacilityRequest.swift
@@ -64,6 +64,7 @@ public extension BulkSearchGetTransientFacilityRequest {
                 case fingerprint
                 case searchID = "search_id"
                 case sessionID = "session_id"
+                case vehicleInfoId = "vehicle_info_id"
             }
 
             /// Latitude in decimal degrees of origin from where each result's distance will be calculated.
@@ -81,6 +82,9 @@ public extension BulkSearchGetTransientFacilityRequest {
 
             /// The work address longitude associated with the user’s commuter benefits card. Longitude must be in [-180, 180].
             let workLongitude: Double?
+            
+            /// An optional vehicle info id.
+            let vehicleInfoId: Int?
 
             let actionID: String?
             let fingerprint: String?
@@ -95,7 +99,6 @@ public extension BulkSearchGetTransientFacilityRequest {
                 case periods
                 case includeWalkingDistance = "include_walking_distance"
                 case sortBy = "sort_by"
-                case vehicleInfoId = "vehicle_info_id"
             }
 
             /// Boolean that denotes whether or not the pricing calculated for this vehicle
@@ -110,9 +113,6 @@ public extension BulkSearchGetTransientFacilityRequest {
             
             /// A string value to sort the items by.
             let sortBy: SortByType?
-            
-            /// An optional vehicle info id.
-            let vehicleInfoId: Int?
         }
 
         fileprivate let queryParameters: QueryParameters
@@ -149,6 +149,7 @@ public extension BulkSearchGetTransientFacilityRequest {
                 originLongitude: originLongitude,
                 workLatitude: workLatitude,
                 workLongitude: workLongitude,
+                vehicleInfoId: vehicleInfoId,
                 actionID: searchTracking?.actionID,
                 fingerprint: searchTracking?.fingerprint,
                 searchID: searchTracking?.searchID,
@@ -158,8 +159,7 @@ public extension BulkSearchGetTransientFacilityRequest {
                 isOversize: isOversize,
                 periods: periods,
                 includeWalkingDistance: includeWalkingDistance,
-                sortBy: sortBy,
-                vehicleInfoId: vehicleInfoId
+                sortBy: sortBy
             )
         }
     }

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
@@ -46,6 +46,8 @@ public extension SearchGetTransientExtensionRates {
             case fingerprint
             case searchID = "search_id"
             case sessionID = "session_id"
+            
+            case vehicleInfoId = "vehicle_info_id"
         }
 
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
@@ -60,13 +62,16 @@ public extension SearchGetTransientExtensionRates {
 
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
-        private let isOversize: Bool
+        private let isOversize: Bool?
 
         /// The rate IDs that the search facility returns.
         private let rateIDs: String
         
         /// The additional hours that will be added to the end time to generate the extension rate
         private let extensionHours: String
+        
+        /// An optional vehicle info id.
+        private let vehicleInfoId: Int?
 
         let actionID: String?
         let fingerprint: String?
@@ -75,16 +80,18 @@ public extension SearchGetTransientExtensionRates {
 
         public init(startDate: Date,
                     endDate: Date,
-                    isOversize: Bool,
+                    isOversize: Bool? = nil,
                     rateIDs: String,
                     extensionHours: String,
-                    searchTracking: SearchTrackingParameters) {
+                    searchTracking: SearchTrackingParameters,
+                    vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
             self.rateIDs = rateIDs
             self.extensionHours = extensionHours
-
+            self.vehicleInfoId = vehicleInfoId
+            
             self.actionID = searchTracking.actionID
             self.fingerprint = searchTracking.fingerprint
             self.searchID = searchTracking.searchID

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
@@ -62,7 +62,7 @@ public extension SearchGetTransientExtensionRates {
 
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
-        private let isOversize: Bool
+        private let isOversize: Bool?
 
         /// The rate IDs that the search facility returns.
         private let rateIDs: String
@@ -80,10 +80,10 @@ public extension SearchGetTransientExtensionRates {
 
         public init(startDate: Date,
                     endDate: Date,
-                    isOversize: Bool,
                     rateIDs: String,
                     extensionHours: String,
                     searchTracking: SearchTrackingParameters,
+                    isOversize: Bool? = nil,
                     vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
@@ -62,7 +62,7 @@ public extension SearchGetTransientExtensionRates {
 
         /// Boolean that denotes whether or not the pricing calculated for this vehicle
         /// will incorporate pricing for an oversize vehicle, if applicable.
-        private let isOversize: Bool?
+        private let isOversize: Bool
 
         /// The rate IDs that the search facility returns.
         private let rateIDs: String
@@ -80,10 +80,10 @@ public extension SearchGetTransientExtensionRates {
 
         public init(startDate: Date,
                     endDate: Date,
+                    isOversize: Bool,
                     rateIDs: String,
                     extensionHours: String,
                     searchTracking: SearchTrackingParameters,
-                    isOversize: Bool? = nil,
                     vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientExtensionRates.swift
@@ -80,10 +80,10 @@ public extension SearchGetTransientExtensionRates {
 
         public init(startDate: Date,
                     endDate: Date,
-                    isOversize: Bool? = nil,
                     rateIDs: String,
                     extensionHours: String,
                     searchTracking: SearchTrackingParameters,
+                    isOversize: Bool? = nil,
                     vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilitiesRequest.swift
@@ -60,6 +60,8 @@ public extension SearchGetTransientFacilitiesRequest {
             case sortBy = "sort_by"
             
             case inFacilityExclusionExperiment = "in_fac_excl_exp"
+            
+            case vehicleInfoId = "vehicle_info_id"
         }
         
         /// Latitude in decimal degrees of origin from where the search will be performed. Latitude must be in [-90, 90].
@@ -117,6 +119,9 @@ public extension SearchGetTransientFacilitiesRequest {
         /// A boolean value indicating whether or not the client is included in the facility exclusion experiment.
         private let inFacilityExclusionExperiment: Bool?
         
+        /// An optional vehicle info id.
+        private let vehicleInfoId: Int?
+        
         let actionID: String?
         let fingerprint: String?
         let searchID: String?
@@ -136,7 +141,8 @@ public extension SearchGetTransientFacilitiesRequest {
                     sortBy: SortByType? = .relevance,
                     inFacilityExclusionExperiment: Bool? = nil,
                     pageSize: Int? = nil,
-                    searchTracking: SearchTrackingParameters? = nil) {
+                    searchTracking: SearchTrackingParameters? = nil,
+                    vehicleInfoId: Int? = nil) {
             self.latitude = latitude
             self.longitude = longitude
             self.originLatitude = originLatitude
@@ -151,6 +157,7 @@ public extension SearchGetTransientFacilitiesRequest {
             self.sortBy = sortBy
             self.inFacilityExclusionExperiment = inFacilityExclusionExperiment
             self.pageSize = pageSize
+            self.vehicleInfoId = vehicleInfoId
             
             self.actionID = searchTracking?.actionID
             self.fingerprint = searchTracking?.fingerprint

--- a/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Requests/SearchGetTransientFacilityRequest.swift
@@ -51,6 +51,7 @@ public extension SearchGetTransientFacilityRequest {
             case sessionID = "session_id"
 
             case includeWalkingDistance = "include_walking_distance"
+            case vehicleInfoId = "vehicle_info_id"
         }
         
         /// Start datetime from which results will be generated. Supported formats are RFC3339 and YYYY-MM-DDTHH:MM:SS.
@@ -86,6 +87,9 @@ public extension SearchGetTransientFacilityRequest {
         /// A boolean value indicating whether to include the walking distance information in the response or not.
         private let includeWalkingDistance: Bool
         
+        /// An optional vehicle info id.
+        private let vehicleInfoId: Int?
+        
         let actionID: String?
         let fingerprint: String?
         let searchID: String?
@@ -99,7 +103,8 @@ public extension SearchGetTransientFacilityRequest {
                     workLatitude: Double? = nil,
                     workLongitude: Double? = nil,
                     searchTracking: SearchTrackingParameters? = nil,
-                    includeWalkingDistance: Bool = true) {
+                    includeWalkingDistance: Bool = true,
+                    vehicleInfoId: Int? = nil) {
             self.startDate = startDate
             self.endDate = endDate
             self.isOversize = isOversize
@@ -107,6 +112,7 @@ public extension SearchGetTransientFacilityRequest {
             self.originLongitude = originLongitude
             self.workLatitude = workLatitude
             self.workLongitude = workLongitude
+            self.vehicleInfoId = vehicleInfoId
             
             self.actionID = searchTracking?.actionID
             self.fingerprint = searchTracking?.fingerprint


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-4758

**Description**
included the `vehicle_info_id` in search everywhere we had `oversize` except for monthly.
