### PR TITLE
IOS-4814: Added vehicle information for oversize fees

### DIFF
--- a/Sources/SpotHeroAPI/Search/Common/Models/OversizeVehicleFeeInformation.swift
+++ b/Sources/SpotHeroAPI/Search/Common/Models/OversizeVehicleFeeInformation.swift
@@ -1,0 +1,35 @@
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public struct OversizeVehicleFeeInformation: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case onsiteFee = "onsite_fee"
+        case oversizeType = "oversize_type"
+        case oversizePolicyId = "oversize_policy_id"
+        case unknownOnsiteFee = "unknown_onsite_fee"
+    }
+
+    public enum OversizeType: String, Codable {
+        case oversize
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let value = try? container.decode(String.self)
+            self = value.flatMap { .init(rawValue: $0) } ?? .unknown
+        }
+    }
+    
+    /// Contains information about the fee that the customer will have to pay on site if their vehicle is considered oversize.
+    public let onsiteFee: Currency?
+
+    /// The type of oversize fee. Right now the only value will be oversize.
+    public let oversizeType: OversizeType
+    
+    /// Can be safely ignored. This is for internal audit only.
+    public let oversizePolicyId: Int
+
+    /// A boolean value indicating whether the `onsite_fee` is unknown or not.
+    public let unknownOnsiteFee: Bool
+}

--- a/Sources/SpotHeroAPI/Search/Transient/Models/BulkTransientFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/BulkTransientFacilityResult.swift
@@ -1,4 +1,4 @@
-// Copyright © 2023 SpotHero, Inc. All rights reserved.
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
 
 public struct BulkTransientFacilityResult: Codable {
     private enum CodingKeys: String, CodingKey {
@@ -7,6 +7,7 @@ public struct BulkTransientFacilityResult: Codable {
         case distance
         case facility
         case options
+        case vehicle
     }
 
     /// The average price of the rates.
@@ -24,4 +25,7 @@ public struct BulkTransientFacilityResult: Codable {
     /// Contains information about misc options available to the user
     /// at a given parking facility based on search criteria and user information.
     public let options: FacilityOptions
+
+    /// The information about oversize vehicle fees if any.
+    public let vehicle: OversizeVehicleFeeInformation?
 }

--- a/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
+++ b/Sources/SpotHeroAPI/Search/Transient/Models/TransientFacilityResult.swift
@@ -1,4 +1,4 @@
-// Copyright © 2023 SpotHero, Inc. All rights reserved.
+// Copyright © 2024 SpotHero, Inc. All rights reserved.
 
 /// Represents an availability search result containing transient facility and rate information.
 public struct TransientFacilityResult: Codable {
@@ -17,4 +17,7 @@ public struct TransientFacilityResult: Codable {
     
     /// Listing of available rates at a given parking facility.
     public let rates: [TransientRateContainer]
+
+    /// The information about oversize vehicle fees if any.
+    public let vehicle: OversizeVehicleFeeInformation?
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-4814

**Description**
Added new fields required for the oversize project.

A new object has been added at the root level:
- `vehicle` (nullable)
    - `onsite_fee` (nullable): contains information about the fee that the customer will have to pay on site if their vehicle is considered oversize.
        - `currency_code`: the currency code.
        - `value`: the price to pay on site in pennies.
    - `oversize_type`: The type of oversize fee. We can ignore this for now (it was added to future proof the API). Right now the only value will be oversize.
    - `oversize_policy_id`: Can be safely ignored. This is for internal audit only.
    - `unknown_onsite_fee`: A boolean value indicating whether the onsite_fee is unknown or not.